### PR TITLE
inner-line diff for source code, word diff for text + calculate diff from any previous commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.0.0
+
+- Enhancements by @alpianon:
+  - word diff for text files, inner line diff for source code files (configurable)
+  - user can choose any previous commit from edited file's git history to calculate the diff against (by default, last available commit is pre-seleted, but one may choose to pre-select last commit by the current git user)
+  - the command `git diff` is used to calculate diffs
+  - user can choose which git diff algorithm to use to calculate the diff
+
 ## 2.4.0
 - Improve: Enable soft-wrap in inline diff editor when hosting(original) editor is soft-wrapped. #11 by @alpianon
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,6 @@
+Copyright (c) 2019-2020 Alberto Pianon - word diff for text files, git 
+diff from any previous commit in file history
+
 Copyright (c) 2018 t9md (Added at 2018.1.5 since I(t9md) forked, changed significantly)
 
 Copyright (c) 2014 Samuel Mueller

--- a/README.md
+++ b/README.md
@@ -2,19 +2,35 @@
 
 Inline git diffs in editor. Can revert/copy specific diff.
 
-![](https://raw.githubusercontent.com/t9md/t9md/5dae170b2f0d78fa922b8a6d90149e45bfcac5c4/img/atom-inline-git-diff.gif)
+  - By default, it renders **inner line diff** when editing source code files, and **word diff** when editing **text files** (txt, markdown, asciidoc, reStructuredText, etc.), but you can change that in settings. 
+
+  - In case of text files, word diff is displayed ignoring possible changes in text wrapping.
+
+  - You may choose to compare the file you are editing with **any previous commit** from the git history of that file. By default the **last available commit** is pre-selected, but in settings you may choose to **'preselect last commit from current git user'** to see all changes that others made to the file since your last modification.
+
+  - Since diffs are calculated by calling `git diff`, you may choose which [git diff algorithm] you prefer using (myers, minimal, patience, histogram).
+
+[git diff algorithm]: https://git-scm.com/docs/diff-options#Documentation/diff-options.txt---diff-algorithmpatienceminimalhistogrammyers
+
+![](./atom-inline-git-diff.gif)
 
 ## This project is fork of [git-diff-details][1] pkg
 
 - This package is fork of great [git-diff-details][1] package by [@samu][samu].
+
 - This package is a result of [experiment][2] to make original git-diff-details how I want.
+
 - I asked to @samu about [releasing this fork project as distinct package][3].
+
 - This project is greatly owning to original @samu's work. Thanks for great successor and his kindness for allowing me to release this pkg.
+
+- [@alpianon][alpianon] added substantial functionalities to get word diff for text files, and to calculate the diff from any previous commit in file history.
 
 [1]: https://github.com/samu/git-diff-details/
 [2]: https://github.com/t9md/git-diff-details
 [3]: https://github.com/samu/git-diff-details/issues/75
 [samu]: https://github.com/samu
+[alpianon]: https://github.com/alpianon
 
 ## Commands
 
@@ -27,6 +43,18 @@ Inline git diffs in editor. Can revert/copy specific diff.
 1. Open editor then execute `inline-git-diff:toggle`.(handled per editor basis)
 2. You can `revert`(`inline-git-diff:revert`) or `copy`(`inline-git-diff:copy-removed-text`)
 3. Disable by executing `inline-git-diff:toggle` again.
+
+## settings
+
+- **Diff Algorithm**: algorithm to use to calculate the diff (myers, minimal, patience, histogram); for more info see the [git diff algorithm] section in git's official guide
+- **Max commits to show in git history**: max number of commits to show in the git history prompt (where you can choose the commit against which to compare the current buffer text)
+- **Preselect last commit from current git user**: preselect last commit from the current git user (instead of the last commit) in the git history prompt
+- **Diff style for text files**: Diff view style for text files (html, xml, latex, markdown, etc.). Choices are:
+  - **line diff**: no highlighting within diffs;
+  - **inner line diff**: if lines have not been added but just modified, highlight the text range from the first to the last modification within the diff (more suitable for source code files);
+  - **word diff**: highlight the words that have been modified within each diff (more suitable for text files and documentation).
+- **Diff style for source files**: diff view style for source code files (same choices as above) 
+- **Text file grammar list**: comma-separated list of grammar scope names, used by inline-git-diff to distinguish text files (documents) from source code files and apply different diff view styles accordingly (see the options above). You can use '\*' as wildcard. Default values (text.\*, source.asciidoc\*, source.gfm) should cover any plain text, asciidoc, markdown, html, latex, reStructuredText and xml files. You may find more info on Atom's grammar scope names at <https://atom.io/packages/file-types>.
 
 ## keymap
 
@@ -55,12 +83,14 @@ My workflow is
 
 ## Differences from original `git-diff-details` package
 
-- No config options
-- Simpler inner-line diff(word diff) by partitioning diff part just **two** part(same and not-same range)
+- Different config options
+- Simpler inner-line diff for by partitioning diff part just **two** part(same and not-same range)
+- Choice between three different diff rendering styles (line diff, inner line diff, word diff; the default for source code files is inner-line diff, while the default for text files is word diff);
+- Calculate the diff from any previous commit in file history
 - Removed diff lines are rendered at `above` of removed place not at `below`
 - Flash copied text on `copy-removed-text`
   - No flash on `revert`,  I tried and given up because I couldn't achieve smooth fadeout effect as it is in `copy-removed-text`
-- Show all diffs in editor  instead of just showing diff at cursor
+- Show all diffs in editor instead of just showing diff at cursor
 - Rename command names(e.g. `undo` command to `revert`)
 - Show all diff kind(`added`, `removed`, `modified`) whereas `git-diff-details` shows `removed` and `modified` only
 - As a result this pkg can revert `added` diff too.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,16 @@
+# Diff Algorithms
+
+The patience/histogram algorithms most of the times work better than
+myers (default git diff algorithm) with text documents because they tend
+to split long (i.e. multi-paragraph) diffs intro many (single-paragraph)
+diffs, making the diff more readable (think of the case of many
+modifications within near paragraphs: with myers one would see a very
+long inline diff, whose word diffs would be difficult to read because
+the whole diff may well exceed the screen height).
+
+However, sometimes patience and histogram are not able to split a long
+diff in the right way (i.e. keeping the corresponding paragraphs
+together) leading to wrong (and highly confusing) word diffs.
+
+A solution may be to use myers, and to split paragraphs within long
+diffs (more than *n* lines) via javascript.

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -3,13 +3,14 @@ JsDiff = require('diff')
 const {repositoryForPath} = require('./utils')
 
 const { execSync } = require('child_process')
-const fs = require('fs')
-const path = require('path')
-const os = require('os')
+
+const { mkdtempSync, mkdirSync, writeFileSync, accessSync } = require('fs')
+const { join, relative, basename, dirname } = require('path')
+const sysTmpDir = String(require('os').tmpdir)
 
 const mkdirIfNotExist = function(dirname){
   try {
-    fs.mkdirSync(dirname)
+    mkdirSync(dirname)
   } 
   catch(err) {
     if (! err.message.startsWith("EEXIST") ) {throw err}
@@ -26,11 +27,11 @@ const checkNewline = function(str) {
   return str
 }
 
-const tmpDirPrefix = path.join(os.tmpdir(), 'inlinegitworddiff-')
-const tmpDir = fs.mkdtempSync(tmpDirPrefix)
-// console.log("tmpDir is "+tmpDir)
+const tmpDirPrefix = join(sysTmpDir, 'inlinegitworddiff-')
+const tmpDir = mkdtempSync(tmpDirPrefix)
+console.log("tmpDir is "+tmpDir)
 const author = noLinebrkCmd("git config user.email")
-// console.log("author is "+author)
+console.log("author is "+author)
 
 
 module.exports = class Diff {
@@ -38,14 +39,14 @@ module.exports = class Diff {
   static init(buffer) {
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()    
-    const relFilePath = path.relative(repo.workingDirectory, filePath)
-    //console.log("INIT: relFilePath is "+relFilePath)
-    const fileBasename = path.basename(filePath)
-    const tmpFileDir = path.join(tmpDir, path.dirname(relFilePath))
-    //console.log("INIT: mkdir "+tmpFileDir)
+    const relFilePath = relative(repo.workingDirectory, filePath)
+    console.log("INIT: relFilePath is "+relFilePath)
+    const fileBasename = basename(filePath)
+    const tmpFileDir = join(tmpDir, dirname(relFilePath))
+    console.log("INIT: mkdir "+tmpFileDir)
     mkdirIfNotExist(tmpFileDir)
-    const tmpFile = path.join(tmpFileDir, fileBasename)
-    //console.log("INIT: tmpFile is: "+tmpFile)
+    const tmpFile = join(tmpFileDir, fileBasename)
+    console.log("INIT: tmpFile is: "+tmpFile)
     var lastCommitHash = noLinebrkCmd(
       'git -C "' + repo.workingDirectory + '" log --author=' + author +
       ' -1 --pretty=format:"%H" "' + relFilePath + '"'
@@ -57,31 +58,31 @@ module.exports = class Diff {
         ' -1 --pretty=format:"%H"'
       )
     }
-    //console.log("lastCommitHash is:"+lastCommitHash)
+    console.log("lastCommitHash is:"+lastCommitHash)
     const tmpFileContent = checkNewline(String(execSync(
       'git -C "' + repo.workingDirectory + '" show ' + 
       lastCommitHash + ':"' + relFilePath + '"'
     ))) /* adds a newline at the end if it is missing to avoid git-diff error
     'No newline at end of file' */
-    fs.writeFileSync(tmpFile, tmpFileContent)
-    //console.log("INIT: saved tmpFile")    
+    writeFileSync(tmpFile, tmpFileContent)
+    console.log("INIT: saved tmpFile")    
   }
 
   static collect (buffer) {
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()
 
-    const relFilePath = path.relative(repo.workingDirectory, filePath)
-    //console.log("REFRESH: relFilePath is "+relFilePath)
-    const fileBasename = path.basename(filePath)
-    const tmpFileDir = path.join(tmpDir, path.dirname(relFilePath))
-    const tmpFile = path.join(tmpFileDir, fileBasename)
-    //console.log("REFRESH: tmpFile is: "+tmpFile)
+    const relFilePath = relative(repo.workingDirectory, filePath)
+    console.log("REFRESH: relFilePath is "+relFilePath)
+    const fileBasename = basename(filePath)
+    const tmpFileDir = join(tmpDir, dirname(relFilePath))
+    const tmpFile = join(tmpFileDir, fileBasename)
+    console.log("REFRESH: tmpFile is: "+tmpFile)
     try { 
-      fs.accessSync(tmpFile) 
+      accessSync(tmpFile) 
     } 
     catch(err) { 
-      //console.log("tmpFile not found, calling init again")
+      console.log("tmpFile not found, calling init again")
       Diff.init(buffer) 
     }
     var gitDiff
@@ -97,7 +98,7 @@ module.exports = class Diff {
       if diffs are found (like diff) so we have to handle output in this way */
       gitDiff = String(err.stdout) 
     }
-    //console.log("Diff:\n"+gitDiff)
+    console.log("Diff:\n"+gitDiff)
     var rawDiffs = []
     var newLineNumber, newStart, newLines, oldLineNumber, oldStart, oldLines
     const errMsg = "cannot interpret the following git diff output:\n"+gitDiff

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -123,9 +123,21 @@ module.exports = class Diff {
     const tmpFileDir = join(tmpDir, dirname(relFilePath))
     ensureDirSync(tmpFileDir)
     const tmpFile = join(tmpFileDir, fileBasename)
+    const gitLog = String(execSync(
+      'git -C "' + repo.workingDirectory + '" log --oneline --name-only ' +
+      '--follow "' + relFilePath + '"'
+    ))
+    const gitLogLines = gitLog.split(linebrk)
+    var originalRelFilePath
+    for (var i=0; i < gitLogLines.length; i++) {
+      if (gitLogLines[i].startsWith(selectedCommitHash)) {
+        originalRelFilePath = gitLogLines[i+1]
+        break
+      }
+    }
     const tmpFileContent = checkNewline(String(execSync(
-      'git -C "' + repo.workingDirectory + '" show ' +
-      selectedCommitHash + ':"' + relFilePath + '"'
+      'git -C "' + repo.workingDirectory + '" show ' + selectedCommitHash + 
+      ':"' + originalRelFilePath + '"'
     )), linebrk) /* adds a newline at the end if it is missing to avoid
     git-diff error 'No newline at end of file' */
     writeFileSync(tmpFile, tmpFileContent)

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -48,7 +48,7 @@ module.exports = class Diff {
     //console.log("INIT: tmpFile is: "+tmpFile)
     var lastCommitHash = noLinebrkCmd(
       'git -C "' + repo.workingDirectory + '" log --author=' + author +
-      ' -1 --pretty=format:"%H"'
+      ' -1 --pretty=format:"%H" "' + relFilePath + '"'
     )
     if (!lastCommitHash) { 
       // author has not commited anything yet, falling back to last commit

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -2,37 +2,6 @@ const {Range} = require('atom')
 JsDiff = require('diff')
 const {repositoryForPath} = require('./utils')
 
-// Line base diff
-// -------------------------
-// - compare two text then split text into three parts which is prefix-range, inner-range and sufix-range.l
-// - Then finally return inner-range information as {start: start of inner-range, length: length of inner-range}.
-// - Now we can highlight inner-range differently to display commonarily of two string.
-// Borrowed and modified from GitHub's electron based app at desktop/desktop.
-// https://github.com/desktop/desktop/pull/2461
-function commonLength (textA, rangeA, textB, rangeB, reverse) {
-  let max = Math.min(rangeA.length, rangeB.length)
-  const startA = reverse ? textA.length - 1 : rangeA.start
-  const startB = reverse ? textB.length - 1 : rangeB.start
-  const stride = reverse ? -1 : 1
-
-  let length = 0
-  while (max-- && textA[startA + length] === textB[startB + length]) length += stride
-  return Math.abs(length)
-}
-
-function computeChangeBetweenTwoText (textA, textB) {
-  let rangeA = {start: 0, length: textA.length}
-  let rangeB = {start: 0, length: textB.length}
-
-  const prefixLength = commonLength(textA, rangeA, textB, rangeB, false)
-  rangeA = {start: prefixLength, length: textA.length - prefixLength}
-  rangeB = {start: prefixLength, length: textB.length - prefixLength}
-
-  const suffixLength = commonLength(textA, rangeA, textB, rangeB, true)
-  rangeB.length -= suffixLength
-  rangeA.length -= suffixLength
-  return [rangeA, rangeB]
-}
 
 module.exports = class Diff {
   static collect (buffer) {
@@ -52,39 +21,74 @@ module.exports = class Diff {
         diffs.push(diff)
       }
       diff.lines[newLineNumber >= 0 ? 'added' : 'removed'].push(line)
+      diff.wlines[newLineNumber >= 0 ? 'added' : 'removed'].push({hunks: []})
     }
 
-    for (const diff of diffs.filter(diff => diff.needComputeInnerLineDiff)) {
-      /* Based on the prepareWordDiffs method of class DiffDetailsDataManager 
-      of package git-diff-details (C) 2014 Samuel Mueller - MIT license */
+    for (const diff of diffs) {
+      var newRow = 0
+      var newCol = 0
+      var oldRow = 0
+      var oldCol = 0
+      var linesRemoved = diff.lines.removed.join(" \n")
+      var linesAdded = diff.lines.added.join(" \n")
 
-      diff.innerLineDiffs = []
-      for (let i = 0; i < diff.lines.added.length; i++) {
-        diff.innerLineDiffs.push({newWords: [], oldWords: []})
-        var newCol = 0
-        var oldCol = 0
-        var wdiff = JsDiff.diffWordsWithSpace(diff.lines.removed[i], diff.lines.added[i])
-        for (let j = 0; j < wdiff.length; j++) {
-          var word = wdiff[j]
-          word.offsetRow = i
-          if (word.added) {
-            word.startCol = newCol
-            word.wordLength = word.value.length
-            newCol += word.wordLength
-            diff.innerLineDiffs[i].newWords.push(word)
-          } else if (word.removed) {
-            word.startCol = oldCol
-            word.wordLength = word.value.length
-            oldCol += word.value.length
-            diff.innerLineDiffs[i].oldWords.push(word)
-          } else {
-            word.wordLength = word.value.length
-            newCol += word.wordLength
-            oldCol += word.wordLength
-            diff.innerLineDiffs[i].newWords.push(word)
-            diff.innerLineDiffs[i].oldWords.push(word)
+      var wdiff = JsDiff.diffWordsWithSpace(linesRemoved, linesAdded)
+      for (var hunk of wdiff) {
+        var hunkValue = hunk.value.replace(/\s\n/g, "\n")
+        hunkValue = hunkValue.replace(/\n\n/g, "\n")
+        var subHunks = hunkValue.split("\n")
+        if (hunk.added) {
+          for (let j = 0; j < subHunks.length; j++) {
+            if (subHunks[j]) {
+              diff.wlines.added[newRow].hunks.push({
+                added: true, 
+                value: subHunks[j], 
+                startCol: newCol,
+                length: subHunks[j].length
+              })
+              newCol += subHunks[j].length
+            }
+            if ((subHunks.length > 1) && (j < (subHunks.length - 1))) {
+              newRow += 1
+              newCol = 0
+            }            
           }
-        }  
+        } else if (hunk.removed) {
+          for (let j = 0; j < subHunks.length; j++) {
+            if (subHunks[j]) {
+              diff.wlines.removed[oldRow].hunks.push({
+                removed: true, 
+                value: subHunks[j], 
+                startCol: oldCol,
+                length: subHunks[j].length
+              })
+              oldCol += subHunks[j].length
+            }
+            if ((subHunks.length > 1) && (j < (subHunks.length - 1))) {
+              oldRow += 1
+              oldCol = 0
+            }            
+          }
+        } else {
+          for (let j = 0; j < subHunks.length; j++) {
+            if (subHunks[j]) {
+              var subHunk = {
+                value: subHunks[j], 
+                length: subHunks[j].length
+              }
+              diff.wlines.added[newRow].hunks.push(subHunk)
+              diff.wlines.removed[oldRow].hunks.push(subHunk)
+              oldCol += subHunks[j].length
+              newCol += subHunks[j].length
+            }
+            if ((subHunks.length > 1) && (j < (subHunks.length - 1))) {
+              newRow += 1
+              newCol = 0
+              oldRow += 1
+              oldCol = 0
+            }            
+          }
+        }
       }
     }
     return diffs
@@ -93,7 +97,7 @@ module.exports = class Diff {
   constructor (startRow, oldLines, newLines) {
     this.startRow = startRow
     this.lines = {added: [], removed: []}
-    this.needComputeInnerLineDiff = newLines === oldLines
+    this.wlines = {added: [], removed: []}
 
     if (oldLines === 0 && newLines > 0) {
       this.kind = 'added'

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -21,7 +21,7 @@ module.exports = class Diff {
         diffs.push(diff)
       }
       diff.lines[newLineNumber >= 0 ? 'added' : 'removed'].push(line)
-      diff.wlines[newLineNumber >= 0 ? 'added' : 'removed'].push({hunks: []})
+      diff.wdiffLines[newLineNumber >= 0 ? 'added' : 'removed'].push({hunks: []})
     }
 
     for (const diff of diffs) {
@@ -31,63 +31,44 @@ module.exports = class Diff {
       var oldCol = 0
       var linesRemoved = diff.lines.removed.join(" \n")
       var linesAdded = diff.lines.added.join(" \n")
-
       var wdiff = JsDiff.diffWordsWithSpace(linesRemoved, linesAdded)
+      /* adding a space before the end of the line is needed in order to allow
+      diffWordsWithSpace method to keep the last word at the end of the line 
+      separate from the first word at the beginning of the next line 
+      (a little bit hacky; to get a cleaner solution, diffWordsWithSpace should
+      be rewritten to handle newlines)*/
       for (var hunk of wdiff) {
-        var hunkValue = hunk.value.replace(/\s\n/g, "\n")
-        hunkValue = hunkValue.replace(/\n\n/g, "\n")
-        var subHunks = hunkValue.split("\n")
-        if (hunk.added) {
-          for (let j = 0; j < subHunks.length; j++) {
-            if (subHunks[j]) {
-              diff.wlines.added[newRow].hunks.push({
-                added: true, 
-                value: subHunks[j], 
-                startCol: newCol,
-                length: subHunks[j].length
-              })
+        var subHunks = hunk.value.replace(/\s\n/g, "\n").replace(/\n\n/g, "\n").split("\n")
+        /* diffWordsWithSpace returns hunks with doubled newlines, we need to 
+        clean them before splitting them in subHunks */
+        for (let j = 0; j < subHunks.length; j++) {
+          if (subHunks[j]) {
+            var subHunk = {
+              added: hunk.added,
+              removed: hunk.removed, 
+              startCol: hunk.added ? newCol : oldCol,
+              length: subHunks[j].length
+            }
+            if (!hunk.removed){
+              diff.wdiffLines.added[newRow].hunks.push(subHunk)
               newCol += subHunks[j].length
             }
-            if ((subHunks.length > 1) && (j < (subHunks.length - 1))) {
-              newRow += 1
-              newCol = 0
-            }            
-          }
-        } else if (hunk.removed) {
-          for (let j = 0; j < subHunks.length; j++) {
-            if (subHunks[j]) {
-              diff.wlines.removed[oldRow].hunks.push({
-                removed: true, 
-                value: subHunks[j], 
-                startCol: oldCol,
-                length: subHunks[j].length
-              })
+            if (!hunk.added){
+              diff.wdiffLines.removed[oldRow].hunks.push(subHunk)
               oldCol += subHunks[j].length
             }
-            if ((subHunks.length > 1) && (j < (subHunks.length - 1))) {
-              oldRow += 1
-              oldCol = 0
-            }            
           }
-        } else {
-          for (let j = 0; j < subHunks.length; j++) {
-            if (subHunks[j]) {
-              var subHunk = {
-                value: subHunks[j], 
-                length: subHunks[j].length
-              }
-              diff.wlines.added[newRow].hunks.push(subHunk)
-              diff.wlines.removed[oldRow].hunks.push(subHunk)
-              oldCol += subHunks[j].length
-              newCol += subHunks[j].length
-            }
-            if ((subHunks.length > 1) && (j < (subHunks.length - 1))) {
+          var newLine = (subHunks.length > 1) && (j < (subHunks.length - 1))
+          if (newLine) {
+            if (!hunk.removed) {
               newRow += 1
               newCol = 0
+            }
+            if (!hunk.added) {
               oldRow += 1
               oldCol = 0
-            }            
-          }
+            }
+          }            
         }
       }
     }
@@ -97,7 +78,7 @@ module.exports = class Diff {
   constructor (startRow, oldLines, newLines) {
     this.startRow = startRow
     this.lines = {added: [], removed: []}
-    this.wlines = {added: [], removed: []}
+    this.wdiffLines = {added: [], removed: []}
 
     if (oldLines === 0 && newLines > 0) {
       this.kind = 'added'

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -20,67 +20,55 @@ const checkNewline = function(str, linebrk) {
 
 const tmpDirPrefix = join(sysTmpDir, 'inlinegitworddiff-')
 const tmpDir = mkdtempSync(tmpDirPrefix)
-//console.log("tmpDir is "+tmpDir)
 const author = noLinebrkCmd("git config user.email")
-//console.log("author is "+author)
 
 
 module.exports = class Diff {
 
   static init(buffer) {
     this.linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
-    this.lbRegexp = (this.linebrk == '\r\n') ? /\s\r\n/g : /\s\n/g
-    //console.log("INIT: linebreak is "+(this.linebrk=='\r\n' ? '\\r\\n' : '\\n'))
+    this.lbRegexp = (this.linebrk == '\r\n') ? /\r\n\s/g : /\n\s/g
     const filePath = buffer.getPath()
-    const repo = repositoryForPath(filePath).getRepo()    
+    const repo = repositoryForPath(filePath).getRepo()
     const relFilePath = relative(repo.workingDirectory, filePath)
-    //console.log("INIT: relFilePath is "+relFilePath)
     const fileBasename = basename(filePath)
     const tmpFileDir = join(tmpDir, dirname(relFilePath))
-    //console.log("INIT: mkdir "+tmpFileDir)
     ensureDirSync(tmpFileDir)
     const tmpFile = join(tmpFileDir, fileBasename)
-    //console.log("INIT: tmpFile is: "+tmpFile)
     var lastCommitHash = noLinebrkCmd(
       'git -C "' + repo.workingDirectory + '" log --author=' + author +
       ' -1 --pretty=format:"%H" "' + relFilePath + '"'
     )
-    if (!lastCommitHash) { 
+    if (!lastCommitHash) {
       // author has not commited anything yet, falling back to last commit
       lastCommitHash = noLinebrkCmd(
         'git -C "' + repo.workingDirectory + '" log'+
         ' -1 --pretty=format:"%H"'
       )
     }
-    //console.log("lastCommitHash is:"+lastCommitHash)
     const tmpFileContent = checkNewline(String(execSync(
-      'git -C "' + repo.workingDirectory + '" show ' + 
+      'git -C "' + repo.workingDirectory + '" show ' +
       lastCommitHash + ':"' + relFilePath + '"'
-    )), this.linebrk) /* adds a newline at the end if it is missing to avoid 
+    )), this.linebrk) /* adds a newline at the end if it is missing to avoid
     git-diff error 'No newline at end of file' */
     writeFileSync(tmpFile, tmpFileContent)
-    //console.log("INIT: saved tmpFile")    
   }
 
   static collect (buffer) {
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()
-    //console.log("REFRESH: linebreak is "+(this.linebrk=='\r\n' ? '\\r\\n' : '\\n'))
     const relFilePath = relative(repo.workingDirectory, filePath)
-    //console.log("REFRESH: relFilePath is "+relFilePath)
     const fileBasename = basename(filePath)
     const tmpFileDir = join(tmpDir, dirname(relFilePath))
     const tmpFile = join(tmpFileDir, fileBasename)
-    //console.log("REFRESH: tmpFile is: "+tmpFile)
-    try { 
-      accessSync(tmpFile) 
-    } 
-    catch(err) { 
-      //console.log("tmpFile not found, calling init again")
-      Diff.init(buffer) 
+    try {
+      accessSync(tmpFile)
+    }
+    catch(err) {
+      Diff.init(buffer)
     }
     var gitDiff
-    try { 
+    try {
       gitDiff = String(execSync(
         'git -C "'+ repo.workingDirectory + '" --no-pager diff -U0 --no-color '+
         '--diff-algorithm=patience '+
@@ -90,9 +78,8 @@ module.exports = class Diff {
     catch(err) {
       /* apparently, when called by atom, git-diff always returns exit code 1
       if diffs are found (like diff) so we have to handle output in this way */
-      gitDiff = String(err.stdout) 
+      gitDiff = String(err.stdout)
     }
-    //console.log("Diff:\n"+gitDiff)
     var rawDiffs = []
     var newLineNumber, newStart, newLines, oldLineNumber, oldStart, oldLines
     const errMsg = "cannot interpret the following git diff output:\n"+gitDiff
@@ -102,13 +89,13 @@ module.exports = class Diff {
       for (var i = 4; i < gitDiffLines.length; i++) {
         var line = gitDiffLines[i]
         if (!line) { continue }
-        var startChar = line.charAt(0) 
+        var startChar = line.charAt(0)
         line = line.substr(1)+this.linebrk
         switch (startChar){
-          case "@": 
+          case "@":
             var items = line.split(" ")
-            if ( !items[1].startsWith("-") || !items[2].startsWith("+") ) { 
-              throw errMsg 
+            if ( !items[1].startsWith("-") || !items[2].startsWith("+") ) {
+              throw errMsg
             }
             for (var j = 1; j < 3; j++) {
               items[j] = items[j].substr(1)
@@ -125,7 +112,7 @@ module.exports = class Diff {
             break
           case "-":
             rawDiffs.push({
-              line: line, 
+              line: line,
               newLineNumber: -1,
               newLines: newLines,
               newStart: newStart,
@@ -137,7 +124,7 @@ module.exports = class Diff {
             break
           case "+":
             rawDiffs.push({
-              line: line, 
+              line: line,
               newLineNumber: newLineNumber,
               newLines: newLines,
               newStart: newStart,
@@ -152,10 +139,6 @@ module.exports = class Diff {
         }
       }
     }
-
-
-/*    const options = {ignoreEolWhitespace: process.platform === 'win32'}
-    const rawDiffs = repo.getLineDiffDetails(repo.relativize(filePath), buffer.getText(), options)*/
 
     const diffs = []
     if (!rawDiffs) return diffs
@@ -180,20 +163,18 @@ module.exports = class Diff {
       var linesAdded = diff.lines.added.join(" ")
       var wdiff = JsDiff.diffWordsWithSpace(linesRemoved, linesAdded)
       /* adding a space before the end of the line is needed in order to allow
-      diffWordsWithSpace method to keep the last word at the end of the line 
-      separate from the first word at the beginning of the next line 
+      diffWordsWithSpace method to keep the last word at the end of the line
+      separate from the first word at the beginning of the next line
       (a little bit hacky; to get a cleaner solution, diffWordsWithSpace should
       be rewritten to handle newlines)*/
       for (var hunk of wdiff) {
-        
+
         var subHunks = hunk.value.replace(this.lbRegexp, this.linebrk).split(this.linebrk)
-        /* diffWordsWithSpace returns hunks with doubled newlines, we need to 
-        clean them before splitting them in subHunks */
         for (let j = 0; j < subHunks.length; j++) {
           if (subHunks[j]) {
             var subHunk = {
               added: hunk.added,
-              removed: hunk.removed, 
+              removed: hunk.removed,
               startCol: hunk.added ? newCol : oldCol,
               length: subHunks[j].length
             }
@@ -216,7 +197,7 @@ module.exports = class Diff {
               oldRow += 1
               oldCol = 0
             }
-          }            
+          }
         }
       }
     }

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,4 +1,5 @@
 const {Range} = require('atom')
+JsDiff = require('diff')
 const {repositoryForPath} = require('./utils')
 
 // Line base diff
@@ -54,10 +55,36 @@ module.exports = class Diff {
     }
 
     for (const diff of diffs.filter(diff => diff.needComputeInnerLineDiff)) {
+      /* Based on the prepareWordDiffs method of class DiffDetailsDataManager 
+      of package git-diff-details (C) 2014 Samuel Mueller - MIT license */
+
       diff.innerLineDiffs = []
       for (let i = 0; i < diff.lines.added.length; i++) {
-        const [rangeA, rangeB] = computeChangeBetweenTwoText(diff.lines.added[i], diff.lines.removed[i])
-        diff.innerLineDiffs.push({added: rangeA, removed: rangeB})
+        diff.innerLineDiffs.push({newWords: [], oldWords: []})
+        var newCol = 0
+        var oldCol = 0
+        var wdiff = JsDiff.diffWordsWithSpace(diff.lines.removed[i], diff.lines.added[i])
+        for (let j = 0; j < wdiff.length; j++) {
+          var word = wdiff[j]
+          word.offsetRow = i
+          if (word.added) {
+            word.startCol = newCol
+            word.wordLength = word.value.length
+            newCol += word.wordLength
+            diff.innerLineDiffs[i].newWords.push(word)
+          } else if (word.removed) {
+            word.startCol = oldCol
+            word.wordLength = word.value.length
+            oldCol += word.value.length
+            diff.innerLineDiffs[i].oldWords.push(word)
+          } else {
+            word.wordLength = word.value.length
+            newCol += word.wordLength
+            oldCol += word.wordLength
+            diff.innerLineDiffs[i].newWords.push(word)
+            diff.innerLineDiffs[i].oldWords.push(word)
+          }
+        }  
       }
     }
     return diffs

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -9,10 +9,6 @@ const { ensureDirSync } = require('fs-extra')
 const { join, relative, basename, dirname } = require('path')
 const sysTmpDir = String(require('os').tmpdir)
 
-const noLinebrkCmd = function(command) {
-  return String(execSync(command)).replace(/\r?\n|\r/g, "")
-}
-
 const checkNewline = function(str, linebrk) {
   if(!str.endsWith(linebrk)) { str = str + linebrk}
   return str
@@ -20,12 +16,10 @@ const checkNewline = function(str, linebrk) {
 
 const tmpDirPrefix = join(sysTmpDir, 'inlinegitworddiff-')
 const tmpDir = mkdtempSync(tmpDirPrefix)
-const author = noLinebrkCmd("git config user.email")
-
 
 module.exports = class Diff {
 
-  static init(buffer) {
+  static init(buffer, selectedCommitHash) {
     this.linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
     this.lbRegexp = (this.linebrk == '\r\n') ? /\r\n\s/g : /\n\s/g
     const filePath = buffer.getPath()
@@ -35,20 +29,9 @@ module.exports = class Diff {
     const tmpFileDir = join(tmpDir, dirname(relFilePath))
     ensureDirSync(tmpFileDir)
     const tmpFile = join(tmpFileDir, fileBasename)
-    var lastCommitHash = noLinebrkCmd(
-      'git -C "' + repo.workingDirectory + '" log --author=' + author +
-      ' -1 --pretty=format:"%H" "' + relFilePath + '"'
-    )
-    if (!lastCommitHash) {
-      // author has not commited anything yet, falling back to last commit
-      lastCommitHash = noLinebrkCmd(
-        'git -C "' + repo.workingDirectory + '" log'+
-        ' -1 --pretty=format:"%H"'
-      )
-    }
     const tmpFileContent = checkNewline(String(execSync(
       'git -C "' + repo.workingDirectory + '" show ' +
-      lastCommitHash + ':"' + relFilePath + '"'
+      selectedCommitHash + ':"' + relFilePath + '"'
     )), this.linebrk) /* adds a newline at the end if it is missing to avoid
     git-diff error 'No newline at end of file' */
     writeFileSync(tmpFile, tmpFileContent)

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -2,13 +2,165 @@ const {Range} = require('atom')
 JsDiff = require('diff')
 const {repositoryForPath} = require('./utils')
 
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const mkdirIfNotExist = function(dirname){
+  try {
+    fs.mkdirSync(dirname)
+  } 
+  catch(err) {
+    if (! err.message.startsWith("EEXIST") ) {throw err}
+  }
+}
+
+const noLinebrkCmd = function(command) {
+  return String(execSync(command)).replace(/\r?\n|\r/g, "")
+}
+
+const checkNewline = function(str) {
+  if(!str.endsWith("\n")) { str = str + "\n"}
+  /* FIXME for windows \r\n */
+  return str
+}
+
+const tmpDirPrefix = path.join(os.tmpdir(), 'inlinegitworddiff-')
+const tmpDir = fs.mkdtempSync(tmpDirPrefix)
+// console.log("tmpDir is "+tmpDir)
+const author = noLinebrkCmd("git config user.email")
+// console.log("author is "+author)
+
 
 module.exports = class Diff {
+
+  static init(buffer) {
+    const filePath = buffer.getPath()
+    const repo = repositoryForPath(filePath).getRepo()    
+    const relFilePath = path.relative(repo.workingDirectory, filePath)
+    //console.log("INIT: relFilePath is "+relFilePath)
+    const fileBasename = path.basename(filePath)
+    const tmpFileDir = path.join(tmpDir, path.dirname(relFilePath))
+    //console.log("INIT: mkdir "+tmpFileDir)
+    mkdirIfNotExist(tmpFileDir)
+    const tmpFile = path.join(tmpFileDir, fileBasename)
+    //console.log("INIT: tmpFile is: "+tmpFile)
+    var lastCommitHash = noLinebrkCmd(
+      'git -C "' + repo.workingDirectory + '" log --author=' + author +
+      ' -1 --pretty=format:"%H"'
+    )
+    if (!lastCommitHash) { 
+      // author has not commited anything yet, falling back to last commit
+      lastCommitHash = noLinebrkCmd(
+        'git -C "' + repo.workingDirectory + '" log'+
+        ' -1 --pretty=format:"%H"'
+      )
+    }
+    //console.log("lastCommitHash is:"+lastCommitHash)
+    const tmpFileContent = checkNewline(String(execSync(
+      'git -C "' + repo.workingDirectory + '" show ' + 
+      lastCommitHash + ':"' + relFilePath + '"'
+    ))) /* adds a newline at the end if it is missing to avoid git-diff error
+    'No newline at end of file' */
+    fs.writeFileSync(tmpFile, tmpFileContent)
+    //console.log("INIT: saved tmpFile")    
+  }
+
   static collect (buffer) {
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()
-    const options = {ignoreEolWhitespace: process.platform === 'win32'}
-    const rawDiffs = repo.getLineDiffDetails(repo.relativize(filePath), buffer.getText(), options)
+
+    const relFilePath = path.relative(repo.workingDirectory, filePath)
+    //console.log("REFRESH: relFilePath is "+relFilePath)
+    const fileBasename = path.basename(filePath)
+    const tmpFileDir = path.join(tmpDir, path.dirname(relFilePath))
+    const tmpFile = path.join(tmpFileDir, fileBasename)
+    //console.log("REFRESH: tmpFile is: "+tmpFile)
+    try { 
+      fs.accessSync(tmpFile) 
+    } 
+    catch(err) { 
+      //console.log("tmpFile not found, calling init again")
+      Diff.init(buffer) 
+    }
+    var gitDiff
+    try { 
+      gitDiff = String(execSync(
+        'git -C "'+ repo.workingDirectory + '" --no-pager diff -U0 --no-color '+
+        '--diff-algorithm=patience '+
+        '--no-index "'+ tmpFile + '" -',
+        {input: checkNewline(buffer.getText()), timeout: 10000}
+    ))}
+    catch(err) {
+      /* apparently, when called by atom, git-diff always returns exit code 1
+      if diffs are found (like diff) so we have to handle output in this way */
+      gitDiff = String(err.stdout) 
+    }
+    //console.log("Diff:\n"+gitDiff)
+    var rawDiffs = []
+    var newLineNumber, newStart, newLines, oldLineNumber, oldStart, oldLines
+    const errMsg = "cannot interpret the following git diff output:\n"+gitDiff
+    if (gitDiff != "\n" && gitDiff != "") {
+      var gitDiffLines = gitDiff.split('\n')
+      if (gitDiffLines < 5) { throw errMsg }
+      for (var i = 4; i < gitDiffLines.length; i++) {
+        var line = gitDiffLines[i]
+        if (!line) { continue }
+        var startChar = line.charAt(0) /*FIXME on windows*/
+        line = line.substr(1)+"\n"
+        switch (startChar){
+          case "@": 
+            var items = line.split(" ")
+            if ( !items[1].startsWith("-") || !items[2].startsWith("+") ) { 
+              throw errMsg 
+            }
+            for (var j = 1; j < 3; j++) {
+              items[j] = items[j].substr(1)
+              if(items[j].indexOf(",") === -1) { items[j] += ",1"; }
+            }
+            var oldSL = items[1].split(",")
+            var newSL = items[2].split(",")
+            oldStart = parseInt(oldSL[0])
+            oldLines = parseInt(oldSL[1])
+            newStart = parseInt(newSL[0])
+            newLines = parseInt(newSL[1])
+            newLineNumber = newStart
+            oldLineNumber = oldStart
+            break
+          case "-":
+            rawDiffs.push({
+              line: line, 
+              newLineNumber: -1,
+              newLines: newLines,
+              newStart: newStart,
+              oldLineNumber: oldLineNumber,
+              oldLines: oldLines,
+              oldStart: oldStart
+            })
+            oldLineNumber += 1
+            break
+          case "+":
+            rawDiffs.push({
+              line: line, 
+              newLineNumber: newLineNumber,
+              newLines: newLines,
+              newStart: newStart,
+              oldLineNumber: -1,
+              oldLines: oldLines,
+              oldStart: oldStart
+            })
+            newLineNumber += 1
+            break
+          default:
+            throw errMsg
+        }
+      }
+    }
+
+
+/*    const options = {ignoreEolWhitespace: process.platform === 'win32'}
+    const rawDiffs = repo.getLineDiffDetails(repo.relativize(filePath), buffer.getText(), options)*/
 
     const diffs = []
     if (!rawDiffs) return diffs
@@ -29,8 +181,8 @@ module.exports = class Diff {
       var newCol = 0
       var oldRow = 0
       var oldCol = 0
-      var linesRemoved = diff.lines.removed.join(" \n")
-      var linesAdded = diff.lines.added.join(" \n")
+      var linesRemoved = diff.lines.removed.join(" ")
+      var linesAdded = diff.lines.added.join(" ")
       var wdiff = JsDiff.diffWordsWithSpace(linesRemoved, linesAdded)
       /* adding a space before the end of the line is needed in order to allow
       diffWordsWithSpace method to keep the last word at the end of the line 
@@ -38,7 +190,7 @@ module.exports = class Diff {
       (a little bit hacky; to get a cleaner solution, diffWordsWithSpace should
       be rewritten to handle newlines)*/
       for (var hunk of wdiff) {
-        var subHunks = hunk.value.replace(/\s\n/g, "\n").replace(/\n\n/g, "\n").split("\n")
+        var subHunks = hunk.value.replace(/\s\n/g, "\n").split("\n")
         /* diffWordsWithSpace returns hunks with doubled newlines, we need to 
         clean them before splitting them in subHunks */
         for (let j = 0; j < subHunks.length; j++) {

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -29,6 +29,7 @@ function commonLength (textA, rangeA, textB, rangeB, reverse) {
   const startA = reverse ? textA.length - 1 : rangeA.start
   const startB = reverse ? textB.length - 1 : rangeB.start
   const stride = reverse ? -1 : 1
+
   let length = 0
   while (max-- && textA[startA + length] === textB[startB + length]) length += stride
   return Math.abs(length)
@@ -37,6 +38,7 @@ function commonLength (textA, rangeA, textB, rangeB, reverse) {
 function computeChangeBetweenTwoText (textA, textB) {
   let rangeA = {start: 0, length: textA.length}
   let rangeB = {start: 0, length: textB.length}
+
   const prefixLength = commonLength(textA, rangeA, textB, rangeB, false)
   rangeA = {start: prefixLength, length: textA.length - prefixLength}
   rangeB = {start: prefixLength, length: textB.length - prefixLength}
@@ -45,6 +47,69 @@ function computeChangeBetweenTwoText (textA, textB) {
   rangeB.length -= suffixLength
   rangeA.length -= suffixLength
   return [rangeA, rangeB]
+}
+
+function parseGitDiff(gitDiff, linebrk) {
+  var rawDiffs = []
+  var newLineNumber, newStart, newLines, oldLineNumber, oldStart, oldLines
+  const errMsg = "cannot interpret the following git diff output:\n"+gitDiff
+  if (gitDiff != "\n" && gitDiff != '\r\n' && gitDiff != "") {
+    var gitDiffLines = gitDiff.split(linebrk)
+    if (gitDiffLines < 5) { throw errMsg }
+    for (var i = 4; i < gitDiffLines.length; i++) {
+      var line = gitDiffLines[i]
+      if (!line) { continue }
+      var startChar = line.charAt(0)
+      line = line.substr(1)+linebrk
+      switch (startChar){
+        case "@":
+          var items = line.split(" ")
+          if ( !items[1].startsWith("-") || !items[2].startsWith("+") ) {
+            throw errMsg
+          }
+          for (var j = 1; j < 3; j++) {
+            items[j] = items[j].substr(1)
+            if(items[j].indexOf(",") === -1) { items[j] += ",1"; }
+          }
+          var oldSL = items[1].split(",")
+          var newSL = items[2].split(",")
+          oldStart = parseInt(oldSL[0])
+          oldLines = parseInt(oldSL[1])
+          newStart = parseInt(newSL[0])
+          newLines = parseInt(newSL[1])
+          newLineNumber = newStart
+          oldLineNumber = oldStart
+          break
+        case "-":
+          rawDiffs.push({
+            line: line,
+            newLineNumber: -1,
+            newLines: newLines,
+            newStart: newStart,
+            oldLineNumber: oldLineNumber,
+            oldLines: oldLines,
+            oldStart: oldStart
+          })
+          oldLineNumber += 1
+          break
+        case "+":
+          rawDiffs.push({
+            line: line,
+            newLineNumber: newLineNumber,
+            newLines: newLines,
+            newStart: newStart,
+            oldLineNumber: -1,
+            oldLines: oldLines,
+            oldStart: oldStart
+          })
+          newLineNumber += 1
+          break
+        default:
+          throw errMsg
+      }
+    }
+  }
+  return rawDiffs
 }
 
 module.exports = class Diff {
@@ -95,66 +160,7 @@ module.exports = class Diff {
       if diffs are found (like diff) so we have to handle output in this way */
       gitDiff = String(err.stdout)
     }
-    var rawDiffs = []
-    var newLineNumber, newStart, newLines, oldLineNumber, oldStart, oldLines
-    const errMsg = "cannot interpret the following git diff output:\n"+gitDiff
-    if (gitDiff != "\n" && gitDiff != '\r\n' && gitDiff != "") {
-      var gitDiffLines = gitDiff.split(linebrk)
-      if (gitDiffLines < 5) { throw errMsg }
-      for (var i = 4; i < gitDiffLines.length; i++) {
-        var line = gitDiffLines[i]
-        if (!line) { continue }
-        var startChar = line.charAt(0)
-        line = line.substr(1)+linebrk
-        switch (startChar){
-          case "@":
-            var items = line.split(" ")
-            if ( !items[1].startsWith("-") || !items[2].startsWith("+") ) {
-              throw errMsg
-            }
-            for (var j = 1; j < 3; j++) {
-              items[j] = items[j].substr(1)
-              if(items[j].indexOf(",") === -1) { items[j] += ",1"; }
-            }
-            var oldSL = items[1].split(",")
-            var newSL = items[2].split(",")
-            oldStart = parseInt(oldSL[0])
-            oldLines = parseInt(oldSL[1])
-            newStart = parseInt(newSL[0])
-            newLines = parseInt(newSL[1])
-            newLineNumber = newStart
-            oldLineNumber = oldStart
-            break
-          case "-":
-            rawDiffs.push({
-              line: line,
-              newLineNumber: -1,
-              newLines: newLines,
-              newStart: newStart,
-              oldLineNumber: oldLineNumber,
-              oldLines: oldLines,
-              oldStart: oldStart
-            })
-            oldLineNumber += 1
-            break
-          case "+":
-            rawDiffs.push({
-              line: line,
-              newLineNumber: newLineNumber,
-              newLines: newLines,
-              newStart: newStart,
-              oldLineNumber: -1,
-              oldLines: oldLines,
-              oldStart: oldStart
-            })
-            newLineNumber += 1
-            break
-          default:
-            throw errMsg
-        }
-      }
-    }
-
+    var rawDiffs = parseGitDiff(gitDiff, linebrk)
     const diffs = []
     if (!rawDiffs) return diffs
 
@@ -166,7 +172,9 @@ module.exports = class Diff {
         diffs.push(diff)
       }
       diff.lines[newLineNumber >= 0 ? 'added' : 'removed'].push(line)
-      diff.wdiffLines[newLineNumber >= 0 ? 'added' : 'removed'].push({hunks: []})
+      if (diffStyle == "word diff"){
+        diff.wdiffLines[newLineNumber >= 0 ? 'added' : 'removed'].push({hunks: []})
+      }
     }
     switch (diffStyle) {
       case "inner line diff":

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -9,8 +9,15 @@ const { ensureDirSync } = require('fs-extra')
 const { join, relative, basename, dirname } = require('path')
 const sysTmpDir = String(require('os').tmpdir)
 
-const checkNewline = function(str, linebrk) {
-  if(!str.endsWith(linebrk)) { str = str + linebrk}
+const fixNewline4GitDiff = function(str) {
+  /* replace windows-style newlines with standard newlines before calling
+  git-diff, because Atom in Windows might save files with standard newlines
+  while keeping windows-style newlines in the edited text */
+  str = str.replace(/\r\n/g, '\n')
+
+  /* add a newline at the end if it is missing to avoid git-diff error
+  'No newline at end of file' */
+  if(!str.endsWith('\n')) { str = str + '\n'}
   return str
 }
 
@@ -54,7 +61,10 @@ function parseGitDiff(gitDiff, linebrk) {
   var newLineNumber, newStart, newLines, oldLineNumber, oldStart, oldLines
   const errMsg = "cannot interpret the following git diff output:\n"+gitDiff
   if (gitDiff != "\n" && gitDiff != '\r\n' && gitDiff != "") {
-    var gitDiffLines = gitDiff.split(linebrk)
+    /* in Windows, git output might use mixed newline styles (i.e.
+    both \r\n and \n in the same output), so we replace \r\n with \n to avoid
+    problems */
+    var gitDiffLines = gitDiff.replace(/\r\n/g, '\n').split('\n')
     if (gitDiffLines < 5) { throw errMsg }
     for (var i = 4; i < gitDiffLines.length; i++) {
       var line = gitDiffLines[i]
@@ -127,7 +137,10 @@ module.exports = class Diff {
       'git -C "' + repo.workingDirectory + '" log --oneline --name-only ' +
       '--follow "' + relFilePath + '"'
     ))
-    const gitLogLines = gitLog.split(linebrk)
+    /* in Windows, git output might use mixed newline styles (i.e.
+    both \r\n and \n in the same output), so we replace \r\n with \n to avoid
+    problems */
+    const gitLogLines = gitLog.replace(/\r\n/g, '\n').split('\n')
     var originalRelFilePath
     for (var i=0; i < gitLogLines.length; i++) {
       if (gitLogLines[i].startsWith(selectedCommitHash)) {
@@ -135,11 +148,10 @@ module.exports = class Diff {
         break
       }
     }
-    const tmpFileContent = checkNewline(String(execSync(
-      'git -C "' + repo.workingDirectory + '" show ' + selectedCommitHash + 
+    const tmpFileContent = fixNewline4GitDiff(String(execSync(
+      'git -C "' + repo.workingDirectory + '" show ' + selectedCommitHash +
       ':"' + originalRelFilePath + '"'
-    )), linebrk) /* adds a newline at the end if it is missing to avoid
-    git-diff error 'No newline at end of file' */
+    )))
     writeFileSync(tmpFile, tmpFileContent)
   }
 
@@ -165,7 +177,7 @@ module.exports = class Diff {
         'git -C "'+ repo.workingDirectory + '" --no-pager diff -U0 --no-color '+
         '--diff-algorithm='+ atom.config.get("inline-git-diff.diffAlgorithm") +
         ' --no-index "'+ tmpFile + '" -',
-        {input: checkNewline(buffer.getText(), linebrk), timeout: 10000}
+        {input: fixNewline4GitDiff(buffer.getText()), timeout: 10000}
     ))}
     catch(err) {
       /* apparently, when called by atom, git-diff always returns exit code 1

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -21,32 +21,34 @@ const noLinebrkCmd = function(command) {
   return String(execSync(command)).replace(/\r?\n|\r/g, "")
 }
 
-const checkNewline = function(str) {
-  if(!str.endsWith("\n")) { str = str + "\n"}
-  /* FIXME for windows \r\n */
+const checkNewline = function(str, linebrk) {
+  if(!str.endsWith(linebrk)) { str = str + linebrk}
   return str
 }
 
 const tmpDirPrefix = join(sysTmpDir, 'inlinegitworddiff-')
 const tmpDir = mkdtempSync(tmpDirPrefix)
-console.log("tmpDir is "+tmpDir)
+//console.log("tmpDir is "+tmpDir)
 const author = noLinebrkCmd("git config user.email")
-console.log("author is "+author)
+//console.log("author is "+author)
 
 
 module.exports = class Diff {
 
   static init(buffer) {
+    this.linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
+    this.lbRegexp = (this.linebrk == '\r\n') ? /\s\r\n/g : /\s\n/g
+    //console.log("INIT: linebreak is "+(this.linebrk=='\r\n' ? '\\r\\n' : '\\n'))
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()    
     const relFilePath = relative(repo.workingDirectory, filePath)
-    console.log("INIT: relFilePath is "+relFilePath)
+    //console.log("INIT: relFilePath is "+relFilePath)
     const fileBasename = basename(filePath)
     const tmpFileDir = join(tmpDir, dirname(relFilePath))
-    console.log("INIT: mkdir "+tmpFileDir)
+    //console.log("INIT: mkdir "+tmpFileDir)
     mkdirIfNotExist(tmpFileDir)
     const tmpFile = join(tmpFileDir, fileBasename)
-    console.log("INIT: tmpFile is: "+tmpFile)
+    //console.log("INIT: tmpFile is: "+tmpFile)
     var lastCommitHash = noLinebrkCmd(
       'git -C "' + repo.workingDirectory + '" log --author=' + author +
       ' -1 --pretty=format:"%H" "' + relFilePath + '"'
@@ -58,31 +60,31 @@ module.exports = class Diff {
         ' -1 --pretty=format:"%H"'
       )
     }
-    console.log("lastCommitHash is:"+lastCommitHash)
+    //console.log("lastCommitHash is:"+lastCommitHash)
     const tmpFileContent = checkNewline(String(execSync(
       'git -C "' + repo.workingDirectory + '" show ' + 
       lastCommitHash + ':"' + relFilePath + '"'
-    ))) /* adds a newline at the end if it is missing to avoid git-diff error
-    'No newline at end of file' */
+    )), this.linebrk) /* adds a newline at the end if it is missing to avoid 
+    git-diff error 'No newline at end of file' */
     writeFileSync(tmpFile, tmpFileContent)
-    console.log("INIT: saved tmpFile")    
+    //console.log("INIT: saved tmpFile")    
   }
 
   static collect (buffer) {
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()
-
+    //console.log("REFRESH: linebreak is "+(this.linebrk=='\r\n' ? '\\r\\n' : '\\n'))
     const relFilePath = relative(repo.workingDirectory, filePath)
-    console.log("REFRESH: relFilePath is "+relFilePath)
+    //console.log("REFRESH: relFilePath is "+relFilePath)
     const fileBasename = basename(filePath)
     const tmpFileDir = join(tmpDir, dirname(relFilePath))
     const tmpFile = join(tmpFileDir, fileBasename)
-    console.log("REFRESH: tmpFile is: "+tmpFile)
+    //console.log("REFRESH: tmpFile is: "+tmpFile)
     try { 
       accessSync(tmpFile) 
     } 
     catch(err) { 
-      console.log("tmpFile not found, calling init again")
+      //console.log("tmpFile not found, calling init again")
       Diff.init(buffer) 
     }
     var gitDiff
@@ -91,25 +93,25 @@ module.exports = class Diff {
         'git -C "'+ repo.workingDirectory + '" --no-pager diff -U0 --no-color '+
         '--diff-algorithm=patience '+
         '--no-index "'+ tmpFile + '" -',
-        {input: checkNewline(buffer.getText()), timeout: 10000}
+        {input: checkNewline(buffer.getText(), this.linebrk), timeout: 10000}
     ))}
     catch(err) {
       /* apparently, when called by atom, git-diff always returns exit code 1
       if diffs are found (like diff) so we have to handle output in this way */
       gitDiff = String(err.stdout) 
     }
-    console.log("Diff:\n"+gitDiff)
+    //console.log("Diff:\n"+gitDiff)
     var rawDiffs = []
     var newLineNumber, newStart, newLines, oldLineNumber, oldStart, oldLines
     const errMsg = "cannot interpret the following git diff output:\n"+gitDiff
-    if (gitDiff != "\n" && gitDiff != "") {
-      var gitDiffLines = gitDiff.split('\n')
+    if (gitDiff != "\n" && gitDiff != '\r\n' && gitDiff != "") {
+      var gitDiffLines = gitDiff.split(this.linebrk)
       if (gitDiffLines < 5) { throw errMsg }
       for (var i = 4; i < gitDiffLines.length; i++) {
         var line = gitDiffLines[i]
         if (!line) { continue }
-        var startChar = line.charAt(0) /*FIXME on windows*/
-        line = line.substr(1)+"\n"
+        var startChar = line.charAt(0) 
+        line = line.substr(1)+this.linebrk
         switch (startChar){
           case "@": 
             var items = line.split(" ")
@@ -191,7 +193,8 @@ module.exports = class Diff {
       (a little bit hacky; to get a cleaner solution, diffWordsWithSpace should
       be rewritten to handle newlines)*/
       for (var hunk of wdiff) {
-        var subHunks = hunk.value.replace(/\s\n/g, "\n").split("\n")
+        
+        var subHunks = hunk.value.replace(this.lbRegexp, this.linebrk).split(this.linebrk)
         /* diffWordsWithSpace returns hunks with doubled newlines, we need to 
         clean them before splitting them in subHunks */
         for (let j = 0; j < subHunks.length; j++) {

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -17,11 +17,40 @@ const checkNewline = function(str, linebrk) {
 const tmpDirPrefix = join(sysTmpDir, 'inlinegitworddiff-')
 const tmpDir = mkdtempSync(tmpDirPrefix)
 
+// Line base diff
+// -------------------------
+// - compare two text then split text into three parts which is prefix-range, inner-range and sufix-range.l
+// - Then finally return inner-range information as {start: start of inner-range, length: length of inner-range}.
+// - Now we can highlight inner-range differently to display commonarily of two string.
+// Borrowed and modified from GitHub's electron based app at desktop/desktop.
+// https://github.com/desktop/desktop/pull/2461
+function commonLength (textA, rangeA, textB, rangeB, reverse) {
+  let max = Math.min(rangeA.length, rangeB.length)
+  const startA = reverse ? textA.length - 1 : rangeA.start
+  const startB = reverse ? textB.length - 1 : rangeB.start
+  const stride = reverse ? -1 : 1
+  let length = 0
+  while (max-- && textA[startA + length] === textB[startB + length]) length += stride
+  return Math.abs(length)
+}
+
+function computeChangeBetweenTwoText (textA, textB) {
+  let rangeA = {start: 0, length: textA.length}
+  let rangeB = {start: 0, length: textB.length}
+  const prefixLength = commonLength(textA, rangeA, textB, rangeB, false)
+  rangeA = {start: prefixLength, length: textA.length - prefixLength}
+  rangeB = {start: prefixLength, length: textB.length - prefixLength}
+
+  const suffixLength = commonLength(textA, rangeA, textB, rangeB, true)
+  rangeB.length -= suffixLength
+  rangeA.length -= suffixLength
+  return [rangeA, rangeB]
+}
+
 module.exports = class Diff {
 
   static init(buffer, selectedCommitHash) {
-    this.linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
-    this.lbRegexp = (this.linebrk == '\r\n') ? /\r\n\s/g : /\n\s/g
+    const linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()
     const relFilePath = relative(repo.workingDirectory, filePath)
@@ -32,23 +61,26 @@ module.exports = class Diff {
     const tmpFileContent = checkNewline(String(execSync(
       'git -C "' + repo.workingDirectory + '" show ' +
       selectedCommitHash + ':"' + relFilePath + '"'
-    )), this.linebrk) /* adds a newline at the end if it is missing to avoid
+    )), linebrk) /* adds a newline at the end if it is missing to avoid
     git-diff error 'No newline at end of file' */
     writeFileSync(tmpFile, tmpFileContent)
   }
 
-  static collect (buffer) {
+  static collect (buffer, diffStyle) {
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()
     const relFilePath = relative(repo.workingDirectory, filePath)
     const fileBasename = basename(filePath)
     const tmpFileDir = join(tmpDir, dirname(relFilePath))
     const tmpFile = join(tmpFileDir, fileBasename)
+    const linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
+    const lbRegexp = (linebrk == '\r\n') ? /\r\n\s/g : /\n\s/g
+
     try {
       accessSync(tmpFile)
     }
     catch(err) {
-      Diff.init(buffer)
+      throw "inline-git-diff: cannot access tmp file to compute diff"
     }
     var gitDiff
     try {
@@ -56,7 +88,7 @@ module.exports = class Diff {
         'git -C "'+ repo.workingDirectory + '" --no-pager diff -U0 --no-color '+
         '--diff-algorithm=patience '+
         '--no-index "'+ tmpFile + '" -',
-        {input: checkNewline(buffer.getText(), this.linebrk), timeout: 10000}
+        {input: checkNewline(buffer.getText(), linebrk), timeout: 10000}
     ))}
     catch(err) {
       /* apparently, when called by atom, git-diff always returns exit code 1
@@ -67,13 +99,13 @@ module.exports = class Diff {
     var newLineNumber, newStart, newLines, oldLineNumber, oldStart, oldLines
     const errMsg = "cannot interpret the following git diff output:\n"+gitDiff
     if (gitDiff != "\n" && gitDiff != '\r\n' && gitDiff != "") {
-      var gitDiffLines = gitDiff.split(this.linebrk)
+      var gitDiffLines = gitDiff.split(linebrk)
       if (gitDiffLines < 5) { throw errMsg }
       for (var i = 4; i < gitDiffLines.length; i++) {
         var line = gitDiffLines[i]
         if (!line) { continue }
         var startChar = line.charAt(0)
-        line = line.substr(1)+this.linebrk
+        line = line.substr(1)+linebrk
         switch (startChar){
           case "@":
             var items = line.split(" ")
@@ -136,53 +168,67 @@ module.exports = class Diff {
       diff.lines[newLineNumber >= 0 ? 'added' : 'removed'].push(line)
       diff.wdiffLines[newLineNumber >= 0 ? 'added' : 'removed'].push({hunks: []})
     }
-
-    for (const diff of diffs) {
-      var newRow = 0
-      var newCol = 0
-      var oldRow = 0
-      var oldCol = 0
-      var linesRemoved = diff.lines.removed.join(" ")
-      var linesAdded = diff.lines.added.join(" ")
-      var wdiff = JsDiff.diffWordsWithSpace(linesRemoved, linesAdded)
-      /* adding a space before the end of the line is needed in order to allow
-      diffWordsWithSpace method to keep the last word at the end of the line
-      separate from the first word at the beginning of the next line
-      (a little bit hacky; to get a cleaner solution, diffWordsWithSpace should
-      be rewritten to handle newlines)*/
-      for (var hunk of wdiff) {
-
-        var subHunks = hunk.value.replace(this.lbRegexp, this.linebrk).split(this.linebrk)
-        for (let j = 0; j < subHunks.length; j++) {
-          if (subHunks[j]) {
-            var subHunk = {
-              added: hunk.added,
-              removed: hunk.removed,
-              startCol: hunk.added ? newCol : oldCol,
-              length: subHunks[j].length
-            }
-            if (!hunk.removed){
-              diff.wdiffLines.added[newRow].hunks.push(subHunk)
-              newCol += subHunks[j].length
-            }
-            if (!hunk.added){
-              diff.wdiffLines.removed[oldRow].hunks.push(subHunk)
-              oldCol += subHunks[j].length
-            }
+    switch (diffStyle) {
+      case "inner line diff":
+        for (const diff of diffs.filter(diff => diff.needComputeInnerLineDiff)) {
+          diff.innerLineDiffs = []
+          for (let i = 0; i < diff.lines.added.length; i++) {
+            const [rangeA, rangeB] = computeChangeBetweenTwoText(diff.lines.added[i], diff.lines.removed[i])
+            diff.innerLineDiffs.push({added: rangeA, removed: rangeB})
           }
-          var newLine = (subHunks.length > 1) && (j < (subHunks.length - 1))
-          if (newLine) {
-            if (!hunk.removed) {
-              newRow += 1
-              newCol = 0
-            }
-            if (!hunk.added) {
-              oldRow += 1
-              oldCol = 0
+        }
+        break
+      case "word diff":
+        for (const diff of diffs) {
+          var newRow = 0
+          var newCol = 0
+          var oldRow = 0
+          var oldCol = 0
+          var linesRemoved = diff.lines.removed.join(" ")
+          var linesAdded = diff.lines.added.join(" ")
+          var wdiff = JsDiff.diffWordsWithSpace(linesRemoved, linesAdded)
+          /* adding a space after the end of the line is needed in order to allow
+          diffWordsWithSpace method to keep the last word at the end of the line
+          separate from the first word at the beginning of the next line
+          (a little bit hacky; to get a cleaner solution, diffWordsWithSpace should
+          be rewritten to handle newlines)*/
+          for (var hunk of wdiff) {
+
+            var subHunks = hunk.value.replace(lbRegexp, linebrk).split(linebrk)
+            for (let j = 0; j < subHunks.length; j++) {
+              if (subHunks[j]) {
+                var subHunk = {
+                  added: hunk.added,
+                  removed: hunk.removed,
+                  startCol: hunk.added ? newCol : oldCol,
+                  length: subHunks[j].length
+                }
+                if (!hunk.removed){
+                  diff.wdiffLines.added[newRow].hunks.push(subHunk)
+                  newCol += subHunks[j].length
+                }
+                if (!hunk.added){
+                  diff.wdiffLines.removed[oldRow].hunks.push(subHunk)
+                  oldCol += subHunks[j].length
+                }
+              }
+              var newLine = (subHunks.length > 1) && (j < (subHunks.length - 1))
+              if (newLine) {
+                if (!hunk.removed) {
+                  newRow += 1
+                  newCol = 0
+                }
+                if (!hunk.added) {
+                  oldRow += 1
+                  oldCol = 0
+                }
+              }
             }
           }
         }
-      }
+        break
+      case "line diff":
+      default:
     }
     return diffs
   }
@@ -191,6 +237,7 @@ module.exports = class Diff {
     this.startRow = startRow
     this.lines = {added: [], removed: []}
     this.wdiffLines = {added: [], removed: []}
+    this.needComputeInnerLineDiff = newLines === oldLines
 
     if (oldLines === 0 && newLines > 0) {
       this.kind = 'added'

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -10,7 +10,7 @@ const sysTmpDir = String(require('os').tmpdir)
 
 const mkdirIfNotExist = function(dirname){
   try {
-    mkdirSync(dirname)
+    mkdirSync(dirname, { recursive: true } )
   } 
   catch(err) {
     if (! err.message.startsWith("EEXIST") ) {throw err}

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -151,8 +151,8 @@ module.exports = class Diff {
     try {
       gitDiff = String(execSync(
         'git -C "'+ repo.workingDirectory + '" --no-pager diff -U0 --no-color '+
-        '--diff-algorithm=patience '+
-        '--no-index "'+ tmpFile + '" -',
+        '--diff-algorithm='+ atom.config.get("inline-git-diff.diffAlgorithm") +
+        ' --no-index "'+ tmpFile + '" -',
         {input: checkNewline(buffer.getText(), linebrk), timeout: 10000}
     ))}
     catch(err) {

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -123,68 +123,74 @@ function parseGitDiff(gitDiff, linebrk) {
 }
 
 module.exports = class Diff {
-
   static init(buffer, selectedCommitHash) {
-    const linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()
-    const relFilePath = relative(repo.workingDirectory, filePath)
-    const fileBasename = basename(filePath)
-    const tmpFileDir = join(tmpDir, dirname(relFilePath))
-    ensureDirSync(tmpFileDir)
-    const tmpFile = join(tmpFileDir, fileBasename)
-    const gitLog = String(execSync(
-      'git -C "' + repo.workingDirectory + '" log --oneline --name-only ' +
-      '--follow "' + relFilePath + '"'
-    ))
-    /* in Windows, git output might use mixed newline styles (i.e.
-    both \r\n and \n in the same output), so we replace \r\n with \n to avoid
-    problems */
-    const gitLogLines = gitLog.replace(/\r\n/g, '\n').split('\n')
-    var originalRelFilePath
-    for (var i=0; i < gitLogLines.length; i++) {
-      if (gitLogLines[i].startsWith(selectedCommitHash)) {
-        originalRelFilePath = gitLogLines[i+1]
-        break
+    if (atom.config.get("inline-git-diff.useGitCommandToCalculateDiff")) {
+      const linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
+      const relFilePath = relative(repo.workingDirectory, filePath)
+      const fileBasename = basename(filePath)
+      const tmpFileDir = join(tmpDir, dirname(relFilePath))
+      ensureDirSync(tmpFileDir)
+      const tmpFile = join(tmpFileDir, fileBasename)
+      const gitLog = String(execSync(
+        'git -C "' + repo.workingDirectory + '" log --oneline --name-only ' +
+        '--follow "' + relFilePath + '"'
+      ))
+      /* in Windows, git output might use mixed newline styles (i.e.
+      both \r\n and \n in the same output), so we replace \r\n with \n to avoid
+      problems */
+      const gitLogLines = gitLog.replace(/\r\n/g, '\n').split('\n')
+      var originalRelFilePath
+      for (var i=0; i < gitLogLines.length; i++) {
+        if (gitLogLines[i].startsWith(selectedCommitHash)) {
+          originalRelFilePath = gitLogLines[i+1]
+          break
+        }
       }
+      const tmpFileContent = fixNewline4GitDiff(String(execSync(
+        'git -C "' + repo.workingDirectory + '" show ' + selectedCommitHash +
+        ':"' + originalRelFilePath + '"'
+      )))
+      writeFileSync(tmpFile, tmpFileContent)
     }
-    const tmpFileContent = fixNewline4GitDiff(String(execSync(
-      'git -C "' + repo.workingDirectory + '" show ' + selectedCommitHash +
-      ':"' + originalRelFilePath + '"'
-    )))
-    writeFileSync(tmpFile, tmpFileContent)
   }
 
   static collect (buffer, diffStyle) {
     const filePath = buffer.getPath()
     const repo = repositoryForPath(filePath).getRepo()
-    const relFilePath = relative(repo.workingDirectory, filePath)
-    const fileBasename = basename(filePath)
-    const tmpFileDir = join(tmpDir, dirname(relFilePath))
-    const tmpFile = join(tmpFileDir, fileBasename)
     const linebrk = (buffer.getText().indexOf('\r\n')>=0) ? '\r\n' : '\n'
     const lbRegexp = (linebrk == '\r\n') ? /\r\n\s/g : /\n\s/g
+    if (atom.config.get("inline-git-diff.useGitCommandToCalculateDiff")) {
+      const relFilePath = relative(repo.workingDirectory, filePath)
+      const fileBasename = basename(filePath)
+      const tmpFileDir = join(tmpDir, dirname(relFilePath))
+      const tmpFile = join(tmpFileDir, fileBasename)
+      try {
+        accessSync(tmpFile)
+      }
+      catch(err) {
+        throw "inline-git-diff: cannot access tmp file to compute diff"
+      }
+      var gitDiff
+      try {
+        gitDiff = String(execSync(
+          'git -C "'+ repo.workingDirectory + '" --no-pager diff -U0 --no-color '+
+          '--diff-algorithm='+ atom.config.get("inline-git-diff.diffAlgorithm") +
+          ' --no-index "'+ tmpFile + '" -',
+          {input: fixNewline4GitDiff(buffer.getText()), timeout: 10000}
+      ))}
+      catch(err) {
+        /* apparently, when called by atom, git-diff always returns exit code 1
+        if diffs are found (like diff) so we have to handle output in this way */
+        gitDiff = String(err.stdout)
+      }
+      var rawDiffs = parseGitDiff(gitDiff, linebrk)
+    } else {
+      const options = {ignoreEolWhitespace: process.platform === 'win32'}
+      var rawDiffs = repo.getLineDiffDetails(repo.relativize(filePath), buffer.getText(), options)
+    }
 
-    try {
-      accessSync(tmpFile)
-    }
-    catch(err) {
-      throw "inline-git-diff: cannot access tmp file to compute diff"
-    }
-    var gitDiff
-    try {
-      gitDiff = String(execSync(
-        'git -C "'+ repo.workingDirectory + '" --no-pager diff -U0 --no-color '+
-        '--diff-algorithm='+ atom.config.get("inline-git-diff.diffAlgorithm") +
-        ' --no-index "'+ tmpFile + '" -',
-        {input: fixNewline4GitDiff(buffer.getText()), timeout: 10000}
-    ))}
-    catch(err) {
-      /* apparently, when called by atom, git-diff always returns exit code 1
-      if diffs are found (like diff) so we have to handle output in this way */
-      gitDiff = String(err.stdout)
-    }
-    var rawDiffs = parseGitDiff(gitDiff, linebrk)
     const diffs = []
     if (!rawDiffs) return diffs
 

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -4,18 +4,10 @@ const {repositoryForPath} = require('./utils')
 
 const { execSync } = require('child_process')
 
-const { mkdtempSync, mkdirSync, writeFileSync, accessSync } = require('fs')
+const { mkdtempSync, writeFileSync, accessSync } = require('fs')
+const { ensureDirSync } = require('fs-extra')
 const { join, relative, basename, dirname } = require('path')
 const sysTmpDir = String(require('os').tmpdir)
-
-const mkdirIfNotExist = function(dirname){
-  try {
-    mkdirSync(dirname, { recursive: true } )
-  } 
-  catch(err) {
-    if (! err.message.startsWith("EEXIST") ) {throw err}
-  }
-}
 
 const noLinebrkCmd = function(command) {
   return String(execSync(command)).replace(/\r?\n|\r/g, "")
@@ -46,7 +38,7 @@ module.exports = class Diff {
     const fileBasename = basename(filePath)
     const tmpFileDir = join(tmpDir, dirname(relFilePath))
     //console.log("INIT: mkdir "+tmpFileDir)
-    mkdirIfNotExist(tmpFileDir)
+    ensureDirSync(tmpFileDir)
     const tmpFile = join(tmpFileDir, fileBasename)
     //console.log("INIT: tmpFile is: "+tmpFile)
     var lastCommitHash = noLinebrkCmd(

--- a/lib/git-history-view.js
+++ b/lib/git-history-view.js
@@ -15,8 +15,8 @@ const { BufferedProcess } = require("atom");
 const noLinebrkCmd = function(command) {
   return String(execSync(command)).replace(/\r?\n|\r/g, "")
 }
-const currentGitUser = noLinebrkCmd("git config user.name");
-
+const currentGitUserName = noLinebrkCmd("git config user.name");
+const currentGitUserEmail = noLinebrkCmd("git config user.email");
 
 class GitHistoryView extends SelectListView {
 
@@ -60,12 +60,12 @@ class GitHistoryView extends SelectListView {
     stdout = function(output) {
       var author, authorEscaped, commit, commitAltered, commits, freeTextMatches, i, item, j, len, len1, message, messageEscaped, ref1, results;
       output = output.replace('\n', '');
-      commits = output.match(/{"author": ".*?","relativeDate": ".*?","fullDate": ".*?","message": ".*?","hash": "[a-f0-9]*?"},/g);
+      commits = output.match(/{"author": ".*?","author_email": ".*?","relativeDate": ".*?","fullDate": ".*?","message": ".*?","hash": "[a-f0-9]*?"},/g);
       output = '';
       if (commits != null) {
         for (i = 0, len = commits.length; i < len; i++) {
           commit = commits[i];
-          freeTextMatches = commit.match(/{"author": "(.*?)","relativeDate": ".*?","fullDate": ".*?","message": "(.*)","hash": "[a-f0-9]*?"},/);
+          freeTextMatches = commit.match(/{"author": "(.*?)","author_email": ".*?","relativeDate": ".*?","fullDate": ".*?","message": "(.*)","hash": "[a-f0-9]*?"},/);
           author = freeTextMatches[1];
           authorEscaped = author.replace(/\\/g, "\\\\").replace(/\"/g, "\\\"");
           commitAltered = commit.replace(author, authorEscaped);
@@ -81,7 +81,7 @@ class GitHistoryView extends SelectListView {
       results = [];
       for (j = 0, len1 = ref1.length; j < len1; j++) {
         item = ref1[j];
-        if (item.author == currentGitUser && !preselectedItemHash) {
+        if ((item.author == currentGitUserName || item.author_email == currentGitUserEmail) && !preselectedItemHash) {
           preselectedItemHash = item.hash // pick up the last commit from current git user
         }
         results.push(logItems.push(item));
@@ -93,7 +93,6 @@ class GitHistoryView extends SelectListView {
         if (code === 0 && logItems.length !== 0) {
           _this.setItems(logItems)
           if (preselectedItemHash && _this._preselectLastCommitFromCurrentGitUser()) {
-            //preselectedItemView = _this.list.find('span.secondary-line:contains(' + preselectedItemHash + ')').parent().parent();
             preselectedItemView = _this.list.find('[data-hash=' + preselectedItemHash + ']');
             if (preselectedItemView) {
               _this.selectItemView(preselectedItemView);
@@ -110,7 +109,7 @@ class GitHistoryView extends SelectListView {
 
   _fetchFileHistory(stdout, exit) {
     var format;
-    format = "{\"author\": \"%an\",\"relativeDate\": \"%cr\",\"fullDate\": \"%ad\",\"message\": \"%s\",\"hash\": \"%h\"},";
+    format = "{\"author\": \"%an\",\"author_email\": \"%ae\",\"relativeDate\": \"%cr\",\"fullDate\": \"%ad\",\"message\": \"%s\",\"hash\": \"%h\"},";
     return new BufferedProcess({
       command: "git",
       args: ["-C", path.dirname(this.file), "log", "--max-count=" + (this._getMaxNumberOfCommits()), "--pretty=format:" + format, "--topo-order", "--date=local", "--follow", this.file],
@@ -152,7 +151,7 @@ class GitHistoryView extends SelectListView {
           }, logItem.message);
           _this.div({
             "class": "secondary-line"
-          }, logItem.author + " authored " + logItem.relativeDate);
+          }, logItem.author + " <" + logItem.author_email + "> authored " + logItem.relativeDate);
           return _this.div({
             "class": "secondary-line"
           }, "" + logItem.fullDate);

--- a/lib/git-history-view.js
+++ b/lib/git-history-view.js
@@ -5,134 +5,134 @@ https://github.com/jakesankey/git-history
 (C) 2014-2017 Jake Sankey
 */
 
-const path = require("path");
-const fs = require("fs");
-const Diff = require('./diff');
-const { execSync } = require('child_process');
-const {$$, SelectListView } = require("atom-space-pen-views");
-const { BufferedProcess } = require("atom");
+const path = require("path")
+const fs = require("fs")
+const Diff = require('./diff')
+const { execSync } = require('child_process')
+const {$$, SelectListView } = require("atom-space-pen-views")
+const { BufferedProcess } = require("atom")
 
 const noLinebrkCmd = function(command) {
   return String(execSync(command)).replace(/\r?\n|\r/g, "")
 }
-const currentGitUserName = noLinebrkCmd("git config user.name");
-const currentGitUserEmail = noLinebrkCmd("git config user.email");
+const currentGitUserName = noLinebrkCmd("git config user.name")
+const currentGitUserEmail = noLinebrkCmd("git config user.email")
 
 class GitHistoryView extends SelectListView {
 
   initialize(inlineGitDiff) {
-    this.inlineGitDiff = inlineGitDiff;
-    this.editor = inlineGitDiff.editor;
-    this.file = this.editor.getPath();
-    super.initialize(this.file);
+    this.inlineGitDiff = inlineGitDiff
+    this.editor = inlineGitDiff.editor
+    this.file = this.editor.getPath()
+    super.initialize(this.file)
     if (this.file) {
-      return this.show();
+      return this.show()
     }
-  };
+  }
 
   show() {
-    this.setLoading("Loading history for " + (path.basename(this.file)));
+    this.setLoading("Loading history for " + (path.basename(this.file)))
     if (this.panel == null) {
       this.panel = atom.workspace.addModalPanel({
         item: this
-      });
+      })
     }
-    this.panel.show();
-    this.storeFocusedElement();
-    this._loadLogData();
-    return this.focusFilterEditor();
-  };
+    this.panel.show()
+    this.storeFocusedElement()
+    this._loadLogData()
+    return this.focusFilterEditor()
+  }
 
   cancel() {
-    var ref1;
-    super.cancel();
+    var ref1
+    super.cancel()
     if ((ref1 = this.panel) != null) {
-      ref1.destroy();
+      ref1.destroy()
     }
-    return this.panel = null;
-  };
+    return this.panel = null
+  }
 
   _loadLogData() {
-    var exit, logItems, stdout, preselectedItemHash, preselectedItemView;
-    logItems = [];
-    preselectedItemHash = null;
-    preselectedItemView = null;
+    var exit, logItems, stdout, preselectedItemHash, preselectedItemView
+    logItems = []
+    preselectedItemHash = null
+    preselectedItemView = null
     stdout = function(output) {
-      var author, authorEscaped, commit, commitAltered, commits, freeTextMatches, i, item, j, len, len1, message, messageEscaped, ref1, results;
-      output = output.replace('\n', '');
-      commits = output.match(/{"author": ".*?","author_email": ".*?","relativeDate": ".*?","fullDate": ".*?","message": ".*?","hash": "[a-f0-9]*?"},/g);
-      output = '';
+      var author, authorEscaped, commit, commitAltered, commits, freeTextMatches, i, item, j, len, len1, message, messageEscaped, ref1, results
+      output = output.replace('\n', '')
+      commits = output.match(/{"author": ".*?","author_email": ".*?","relativeDate": ".*?","fullDate": ".*?","message": ".*?","hash": "[a-f0-9]*?"},/g)
+      output = ''
       if (commits != null) {
         for (i = 0, len = commits.length; i < len; i++) {
-          commit = commits[i];
-          freeTextMatches = commit.match(/{"author": "(.*?)","author_email": ".*?","relativeDate": ".*?","fullDate": ".*?","message": "(.*)","hash": "[a-f0-9]*?"},/);
-          author = freeTextMatches[1];
-          authorEscaped = author.replace(/\\/g, "\\\\").replace(/\"/g, "\\\"");
-          commitAltered = commit.replace(author, authorEscaped);
-          message = freeTextMatches[2];
-          messageEscaped = message.replace(/\\/g, "\\\\").replace(/\"/g, "\\\"");
-          output += commitAltered.replace(message, messageEscaped);
+          commit = commits[i]
+          freeTextMatches = commit.match(/{"author": "(.*?)","author_email": ".*?","relativeDate": ".*?","fullDate": ".*?","message": "(.*)","hash": "[a-f0-9]*?"},/)
+          author = freeTextMatches[1]
+          authorEscaped = author.replace(/\\/g, "\\\\").replace(/\"/g, "\\\"")
+          commitAltered = commit.replace(author, authorEscaped)
+          message = freeTextMatches[2]
+          messageEscaped = message.replace(/\\/g, "\\\\").replace(/\"/g, "\\\"")
+          output += commitAltered.replace(message, messageEscaped)
         }
       }
       if ((output != null ? output.substring(output.length - 1) : void 0) === ",") {
-        output = output.substring(0, output.length - 1);
+        output = output.substring(0, output.length - 1)
       }
-      ref1 = JSON.parse("[" + output + "]");
-      results = [];
+      ref1 = JSON.parse("[" + output + "]")
+      results = []
       for (j = 0, len1 = ref1.length; j < len1; j++) {
-        item = ref1[j];
+        item = ref1[j]
         if ((item.author == currentGitUserName || item.author_email == currentGitUserEmail) && !preselectedItemHash) {
           preselectedItemHash = item.hash // pick up the last commit from current git user
         }
-        results.push(logItems.push(item));
+        results.push(logItems.push(item))
       }
-      return results;
-    };
+      return results
+    }
     exit = (function(_this) {
       return function(code) {
         if (code === 0 && logItems.length !== 0) {
           _this.setItems(logItems)
           if (preselectedItemHash && _this._preselectLastCommitFromCurrentGitUser()) {
-            preselectedItemView = _this.list.find('[data-hash=' + preselectedItemHash + ']');
+            preselectedItemView = _this.list.find('[data-hash=' + preselectedItemHash + ']')
             if (preselectedItemView) {
-              _this.selectItemView(preselectedItemView);
+              _this.selectItemView(preselectedItemView)
             }
           }
-          return true;
+          return true
         } else {
-          return _this.setError("No history found for " + (path.basename(_this.file)));
+          return _this.setError("No history found for " + (path.basename(_this.file)))
         }
-      };
-    })(this);
-    return this._fetchFileHistory(stdout, exit);
-  };
+      }
+    })(this)
+    return this._fetchFileHistory(stdout, exit)
+  }
 
   _fetchFileHistory(stdout, exit) {
-    var format;
-    format = "{\"author\": \"%an\",\"author_email\": \"%ae\",\"relativeDate\": \"%cr\",\"fullDate\": \"%ad\",\"message\": \"%s\",\"hash\": \"%h\"},";
+    var format
+    format = "{\"author\": \"%an\",\"author_email\": \"%ae\",\"relativeDate\": \"%cr\",\"fullDate\": \"%ad\",\"message\": \"%s\",\"hash\": \"%h\"},"
     return new BufferedProcess({
       command: "git",
       args: ["-C", path.dirname(this.file), "log", "--max-count=" + (this._getMaxNumberOfCommits()), "--pretty=format:" + format, "--topo-order", "--date=local", "--follow", this.file],
       stdout: stdout,
       exit: exit
-    });
-  };
+    })
+  }
 
   _getMaxNumberOfCommits() {
-    return atom.config.get("inline-git-diff.maxCommitsToShowInGitHistory");
-  };
+    return atom.config.get("inline-git-diff.maxCommitsToShowInGitHistory")
+  }
 
   _preselectLastCommitFromCurrentGitUser() {
     return atom.config.get("inline-git-diff.preselectLastCommitFromCurrentGitUser")
   }
 
   getFilterKey() {
-    return "message";
-  };
+    return "message"
+  }
 
   viewForItem(logItem) {
-    var fileName;
-    fileName = path.basename(this.file);
+    var fileName
+    fileName = path.basename(this.file)
     return $$(function() {
       return this.li({
         "data-hash": logItem.hash,
@@ -144,21 +144,21 @@ class GitHistoryView extends SelectListView {
           }, function() {
             return _this.span({
               "class": "secondary-line"
-            }, "" + logItem.hash);
-          });
+            }, "" + logItem.hash)
+          })
           _this.span({
             "class": "primary-line"
-          }, logItem.message);
+          }, logItem.message)
           _this.div({
             "class": "secondary-line"
-          }, logItem.author + " <" + logItem.author_email + "> authored " + logItem.relativeDate);
+          }, logItem.author + " <" + logItem.author_email + "> authored " + logItem.relativeDate)
           return _this.div({
             "class": "secondary-line"
-          }, "" + logItem.fullDate);
-        };
-      })(this));
-    });
-  };
+          }, "" + logItem.fullDate)
+        }
+      })(this))
+    })
+  }
 
   confirmed(logItem) {
      Diff.init(this.editor.buffer, logItem.hash)
@@ -167,7 +167,7 @@ class GitHistoryView extends SelectListView {
      this.inlineGitDiff.updateStatusBar()
      this.inlineGitDiff.refreshDiff()
      this.cancel()
-  };
-};
+  }
+}
 
-module.exports = GitHistoryView;
+module.exports = GitHistoryView

--- a/lib/git-history-view.js
+++ b/lib/git-history-view.js
@@ -20,9 +20,9 @@ const currentGitUserEmail = noLinebrkCmd("git config user.email")
 
 class GitHistoryView extends SelectListView {
 
-  initialize(inlineGitDiff) {
-    this.inlineGitDiff = inlineGitDiff
-    this.editor = inlineGitDiff.editor
+  initialize(editor, callbackOnConfirmed) {
+    this.callbackOnConfirmed = callbackOnConfirmed
+    this.editor = editor
     this.file = this.editor.getPath()
     super.initialize(this.file)
     if (this.file) {
@@ -162,11 +162,7 @@ class GitHistoryView extends SelectListView {
 
   confirmed(logItem) {
      Diff.init(this.editor.buffer, logItem.hash)
-     //FIXME use callback instead
-     this.inlineGitDiff.enabled = true
-     this.inlineGitDiff.editor.element.classList.toggle('has-inline-git-diff', true)
-     this.inlineGitDiff.updateStatusBar()
-     this.inlineGitDiff.refreshDiff()
+     this.callbackOnConfirmed()
      this.cancel()
   }
 }

--- a/lib/git-history-view.js
+++ b/lib/git-history-view.js
@@ -15,8 +15,6 @@ const { BufferedProcess } = require("atom")
 const noLinebrkCmd = function(command) {
   return String(execSync(command)).replace(/\r?\n|\r/g, "")
 }
-const currentGitUserName = noLinebrkCmd("git config user.name")
-const currentGitUserEmail = noLinebrkCmd("git config user.email")
 
 class GitHistoryView extends SelectListView {
 
@@ -53,10 +51,12 @@ class GitHistoryView extends SelectListView {
   }
 
   _loadLogData() {
-    var exit, logItems, stdout, preselectedItemHash, preselectedItemView
+    var exit, logItems, stdout, preselectedItemHash, preselectedItemView, currentGitUserName, currentGitUserEmail
     logItems = []
     preselectedItemHash = null
     preselectedItemView = null
+    currentGitUserName = noLinebrkCmd("git config user.name")
+    currentGitUserEmail = noLinebrkCmd("git config user.email")
     stdout = function(output) {
       var author, authorEscaped, commit, commitAltered, commits, freeTextMatches, i, item, j, len, len1, message, messageEscaped, ref1, results
       output = output.replace('\n', '')

--- a/lib/git-history-view.js
+++ b/lib/git-history-view.js
@@ -1,5 +1,5 @@
 /* (C) 2019 Alberto Pianon pianon@array.eu
-This code has been mostly taken and converted to javascript from file
+This code has been mostly taken and adapted from file
 lib/git-history-view.coffee of 'git-history' package
 https://github.com/jakesankey/git-history
 (C) 2014-2017 Jake Sankey
@@ -8,14 +8,15 @@ https://github.com/jakesankey/git-history
 const path = require("path");
 const fs = require("fs");
 const Diff = require('./diff');
+const { execSync } = require('child_process');
 const {$$, SelectListView } = require("atom-space-pen-views");
-const BufferedProcess = require("atom").BufferedProcess;
+const { BufferedProcess } = require("atom");
 
-/* FIXME: uncomment and use author to pre-select last author's commit
 const noLinebrkCmd = function(command) {
   return String(execSync(command)).replace(/\r?\n|\r/g, "")
 }
-const author = noLinebrkCmd("git config user.email")*/
+const currentGitUser = noLinebrkCmd("git config user.name");
+
 
 class GitHistoryView extends SelectListView {
 
@@ -52,8 +53,10 @@ class GitHistoryView extends SelectListView {
   };
 
   _loadLogData() {
-    var exit, logItems, stdout;
+    var exit, logItems, stdout, preselectedItemHash, preselectedItemView;
     logItems = [];
+    preselectedItemHash = null;
+    preselectedItemView = null;
     stdout = function(output) {
       var author, authorEscaped, commit, commitAltered, commits, freeTextMatches, i, item, j, len, len1, message, messageEscaped, ref1, results;
       output = output.replace('\n', '');
@@ -78,6 +81,9 @@ class GitHistoryView extends SelectListView {
       results = [];
       for (j = 0, len1 = ref1.length; j < len1; j++) {
         item = ref1[j];
+        if (item.author == currentGitUser && !preselectedItemHash) {
+          preselectedItemHash = item.hash // pick up the last commit from current git user
+        }
         results.push(logItems.push(item));
       }
       return results;
@@ -85,7 +91,15 @@ class GitHistoryView extends SelectListView {
     exit = (function(_this) {
       return function(code) {
         if (code === 0 && logItems.length !== 0) {
-          return _this.setItems(logItems);
+          _this.setItems(logItems)
+          if (preselectedItemHash && _this._preselectLastCommitFromCurrentGitUser()) {
+            //preselectedItemView = _this.list.find('span.secondary-line:contains(' + preselectedItemHash + ')').parent().parent();
+            preselectedItemView = _this.list.find('[data-hash=' + preselectedItemHash + ']');
+            if (preselectedItemView) {
+              _this.selectItemView(preselectedItemView);
+            }
+          }
+          return true;
         } else {
           return _this.setError("No history found for " + (path.basename(_this.file)));
         }
@@ -105,15 +119,13 @@ class GitHistoryView extends SelectListView {
     });
   };
 
-  _getMaxNumberOfCommits() {  // FIXME
-    return 10;
-    //return atom.config.get("git-history.maxCommits");
+  _getMaxNumberOfCommits() {
+    return atom.config.get("inline-git-diff.maxCommitsToShowInGitHistory");
   };
 
-  _isDiffEnabled() {
-    return false;
-    //FIMXE return atom.config.get("git-history.showDiff");
-  };
+  _preselectLastCommitFromCurrentGitUser() {
+    return atom.config.get("inline-git-diff.preselectLastCommitFromCurrentGitUser")
+  }
 
   getFilterKey() {
     return "message";
@@ -124,6 +136,7 @@ class GitHistoryView extends SelectListView {
     fileName = path.basename(this.file);
     return $$(function() {
       return this.li({
+        "data-hash": logItem.hash,
         "class": "two-lines"
       }, (function(_this) {
         return function() {
@@ -151,10 +164,10 @@ class GitHistoryView extends SelectListView {
   confirmed(logItem) {
      Diff.init(this.editor.buffer, logItem.hash)
      this.inlineGitDiff.enabled = true
-     this.inlineGitDiff.editor.element.classList.toggle('has-inline-git-diff', this.inlineGitDiff.enabled)
+     this.inlineGitDiff.editor.element.classList.toggle('has-inline-git-diff', true)
      this.inlineGitDiff.updateStatusBar()
      this.inlineGitDiff.refreshDiff()
-     this.cancel();
+     this.cancel()
   };
 };
 

--- a/lib/git-history-view.js
+++ b/lib/git-history-view.js
@@ -1,0 +1,161 @@
+/* (C) 2019 Alberto Pianon pianon@array.eu
+This code has been mostly taken and converted to javascript from file
+lib/git-history-view.coffee of 'git-history' package
+https://github.com/jakesankey/git-history
+(C) 2014-2017 Jake Sankey
+*/
+
+const path = require("path");
+const fs = require("fs");
+const Diff = require('./diff');
+const {$$, SelectListView } = require("atom-space-pen-views");
+const BufferedProcess = require("atom").BufferedProcess;
+
+/* FIXME: uncomment and use author to pre-select last author's commit
+const noLinebrkCmd = function(command) {
+  return String(execSync(command)).replace(/\r?\n|\r/g, "")
+}
+const author = noLinebrkCmd("git config user.email")*/
+
+class GitHistoryView extends SelectListView {
+
+  initialize(inlineGitDiff) {
+    this.inlineGitDiff = inlineGitDiff;
+    this.editor = inlineGitDiff.editor;
+    this.file = this.editor.getPath();
+    super.initialize(this.file);
+    if (this.file) {
+      return this.show();
+    }
+  };
+
+  show() {
+    this.setLoading("Loading history for " + (path.basename(this.file)));
+    if (this.panel == null) {
+      this.panel = atom.workspace.addModalPanel({
+        item: this
+      });
+    }
+    this.panel.show();
+    this.storeFocusedElement();
+    this._loadLogData();
+    return this.focusFilterEditor();
+  };
+
+  cancel() {
+    var ref1;
+    super.cancel();
+    if ((ref1 = this.panel) != null) {
+      ref1.destroy();
+    }
+    return this.panel = null;
+  };
+
+  _loadLogData() {
+    var exit, logItems, stdout;
+    logItems = [];
+    stdout = function(output) {
+      var author, authorEscaped, commit, commitAltered, commits, freeTextMatches, i, item, j, len, len1, message, messageEscaped, ref1, results;
+      output = output.replace('\n', '');
+      commits = output.match(/{"author": ".*?","relativeDate": ".*?","fullDate": ".*?","message": ".*?","hash": "[a-f0-9]*?"},/g);
+      output = '';
+      if (commits != null) {
+        for (i = 0, len = commits.length; i < len; i++) {
+          commit = commits[i];
+          freeTextMatches = commit.match(/{"author": "(.*?)","relativeDate": ".*?","fullDate": ".*?","message": "(.*)","hash": "[a-f0-9]*?"},/);
+          author = freeTextMatches[1];
+          authorEscaped = author.replace(/\\/g, "\\\\").replace(/\"/g, "\\\"");
+          commitAltered = commit.replace(author, authorEscaped);
+          message = freeTextMatches[2];
+          messageEscaped = message.replace(/\\/g, "\\\\").replace(/\"/g, "\\\"");
+          output += commitAltered.replace(message, messageEscaped);
+        }
+      }
+      if ((output != null ? output.substring(output.length - 1) : void 0) === ",") {
+        output = output.substring(0, output.length - 1);
+      }
+      ref1 = JSON.parse("[" + output + "]");
+      results = [];
+      for (j = 0, len1 = ref1.length; j < len1; j++) {
+        item = ref1[j];
+        results.push(logItems.push(item));
+      }
+      return results;
+    };
+    exit = (function(_this) {
+      return function(code) {
+        if (code === 0 && logItems.length !== 0) {
+          return _this.setItems(logItems);
+        } else {
+          return _this.setError("No history found for " + (path.basename(_this.file)));
+        }
+      };
+    })(this);
+    return this._fetchFileHistory(stdout, exit);
+  };
+
+  _fetchFileHistory(stdout, exit) {
+    var format;
+    format = "{\"author\": \"%an\",\"relativeDate\": \"%cr\",\"fullDate\": \"%ad\",\"message\": \"%s\",\"hash\": \"%h\"},";
+    return new BufferedProcess({
+      command: "git",
+      args: ["-C", path.dirname(this.file), "log", "--max-count=" + (this._getMaxNumberOfCommits()), "--pretty=format:" + format, "--topo-order", "--date=local", "--follow", this.file],
+      stdout: stdout,
+      exit: exit
+    });
+  };
+
+  _getMaxNumberOfCommits() {  // FIXME
+    return 10;
+    //return atom.config.get("git-history.maxCommits");
+  };
+
+  _isDiffEnabled() {
+    return false;
+    //FIMXE return atom.config.get("git-history.showDiff");
+  };
+
+  getFilterKey() {
+    return "message";
+  };
+
+  viewForItem(logItem) {
+    var fileName;
+    fileName = path.basename(this.file);
+    return $$(function() {
+      return this.li({
+        "class": "two-lines"
+      }, (function(_this) {
+        return function() {
+          _this.div({
+            "class": "pull-right"
+          }, function() {
+            return _this.span({
+              "class": "secondary-line"
+            }, "" + logItem.hash);
+          });
+          _this.span({
+            "class": "primary-line"
+          }, logItem.message);
+          _this.div({
+            "class": "secondary-line"
+          }, logItem.author + " authored " + logItem.relativeDate);
+          return _this.div({
+            "class": "secondary-line"
+          }, "" + logItem.fullDate);
+        };
+      })(this));
+    });
+  };
+
+  confirmed(logItem) {
+     Diff.init(this.editor.buffer, logItem.hash)
+     this.inlineGitDiff.enabled = true
+     this.inlineGitDiff.editor.element.classList.toggle('has-inline-git-diff', this.inlineGitDiff.enabled)
+     this.inlineGitDiff.updateStatusBar()
+     this.inlineGitDiff.refreshDiff()
+     this.cancel();
+  };
+};
+
+module.exports = GitHistoryView;

--- a/lib/git-history-view.js
+++ b/lib/git-history-view.js
@@ -133,7 +133,7 @@ class GitHistoryView extends SelectListView {
   viewForItem(logItem) {
     var fileName
     fileName = path.basename(this.file)
-    return $$(function() {
+    return $$(function() { //FIXME the following code, converted from coffee, looks awkward
       return this.li({
         "data-hash": logItem.hash,
         "class": "two-lines"
@@ -162,6 +162,7 @@ class GitHistoryView extends SelectListView {
 
   confirmed(logItem) {
      Diff.init(this.editor.buffer, logItem.hash)
+     //FIXME use callback instead
      this.inlineGitDiff.enabled = true
      this.inlineGitDiff.editor.element.classList.toggle('has-inline-git-diff', true)
      this.inlineGitDiff.updateStatusBar()

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -214,7 +214,13 @@ class InlineGitDiff {
     for (let i = 0; i < diff.wdiffLines.added.length; i++) {
       for (let j = 0; j < diff.wdiffLines.added[i].hunks.length; j++) {
         if (diff.wdiffLines.added[i].hunks[j].added) {
-          const range = toRange(diff.startRow + i, diff.wdiffLines.added[i].hunks[j])
+          var hunk = diff.wdiffLines.added[i].hunks[j]
+          var prev_hunk = diff.wdiffLines.added[i].hunks[j-1]
+          if (prev_hunk && prev_hunk.length == 1 && !prev_hunk.added) {
+            hunk.startCol -= 1
+            hunk.length +=1
+          }
+          const range = toRange(diff.startRow + i, hunk)
           var wordDiffText = this.editor.getTextInBufferRange(range)
           var isAtLineEnd = range.end.column === this.editor.lineTextForBufferRow(range.end.row).length
           var isAtLineStart = range.start.column === 0
@@ -234,7 +240,13 @@ class InlineGitDiff {
     for (let i = 0; i < diff.wdiffLines.removed.length; i++) {
       for (let k = 0; k < diff.wdiffLines.removed[i].hunks.length; k++) {
         if (diff.wdiffLines.removed[i].hunks[k].removed) {
-          const range = toRange(i, diff.wdiffLines.removed[i].hunks[k])
+          var hunk = diff.wdiffLines.removed[i].hunks[k]
+          var prev_hunk = diff.wdiffLines.removed[i].hunks[k-1]
+          if (prev_hunk && prev_hunk.length == 1 && !prev_hunk.removed) {
+            hunk.startCol -= 1
+            hunk.length +=1
+          }
+          const range = toRange(i, hunk)
           var wordDiffText = editorInEditor.getTextInBufferRange(range)
           var isAtLineEnd = range.end.column === editorInEditor.lineTextForBufferRow(range.end.row).length - (editorInEditor.getLastBufferRow() === range.end.row ? 1 : 0) // Why '- 1'? Because removed diffs have a dummy space at the end of the last line
           var isAtLineStart = range.start.column === 0

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -3,6 +3,7 @@ const {repositoryForPath, withKeepingRelativeScrollPosition, decorateRange} = re
 const Diff = require('./diff')
 const WHOLE_RANGE = Object.freeze([[0, 0], [Infinity], [Infinity]])
 const statusBar = require('./status-bar')
+const GitHistoryView = require('./git-history-view')
 
 function buildEditorForRemovedDiff (grammar, diff, isSoftWrapped, preferredLineLength, softWrapAtPreferredLineLength) {
   const editor = new TextEditor({
@@ -83,13 +84,15 @@ class InlineGitDiff {
     if (enabled === this.enabled) {
       return false
     }
-    this.enabled = enabled
-    this.editor.element.classList.toggle('has-inline-git-diff', this.enabled)
-    this.updateStatusBar()
-    if (this.enabled) { 
-      Diff.init(this.editor.buffer) 
+    if (enabled) {
+      new GitHistoryView(this);
+    } else {
+      this.enabled = false;
+      this.editor.element.classList.toggle('has-inline-git-diff', false)
+      this.updateStatusBar();
+      this.refreshDiff();
     }
-    this.refreshDiff()
+
     return true
   }
 

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -209,15 +209,24 @@ class InlineGitDiff {
   renderWordDiff (diff, editorInEditor) {
     const toRange = (row, {startCol, length}) => Range.fromPointWithDelta([row, startCol], 0, length)
     const markers = []
-
+    var markersAddedAtLineStart = []
+    var markersAddedAtLineEnd = []
     for (let i = 0; i < diff.wdiffLines.added.length; i++) {
       for (let j = 0; j < diff.wdiffLines.added[i].hunks.length; j++) {
         if (diff.wdiffLines.added[i].hunks[j].added) {
           const range = toRange(diff.startRow + i, diff.wdiffLines.added[i].hunks[j])
           var wordDiffText = this.editor.getTextInBufferRange(range)
           var isAtLineEnd = range.end.column === this.editor.lineTextForBufferRow(range.end.row).length
-          if ( wordDiffText != " " || isAtLineEnd ){ // single space wdiffs not at the end of the line are due to text hard-wrapping, do not highlight them
+          var isAtLineStart = range.start.column === 0
+          if ( wordDiffText != " " || isAtLineEnd ) { // Text hard-wrap hack 1: single space wdiffs not at the end of the line are due to text hard-wrapping, do not highlight them
             markers.push(decorateRange(this.editor, range, {type: 'highlight', class: 'inline-git-diff-added-inner'}))
+            // Text hard-wrap hack 2: save markers at the start and at the end of line, for subsequent use (see below)
+            if (isAtLineStart) {
+              markersAddedAtLineStart[range.start.row - diff.startRow] = {marker: markers[markers.length-1], text: wordDiffText.trim()}
+            }
+            if (isAtLineEnd) {
+              markersAddedAtLineEnd[range.start.row - diff.startRow] = {marker: markers[markers.length-1], text: wordDiffText.trim()}
+            }
           }
         }
       }
@@ -228,8 +237,16 @@ class InlineGitDiff {
           const range = toRange(i, diff.wdiffLines.removed[i].hunks[k])
           var wordDiffText = editorInEditor.getTextInBufferRange(range)
           var isAtLineEnd = range.end.column === editorInEditor.lineTextForBufferRow(range.end.row).length - (editorInEditor.getLastBufferRow() === range.end.row ? 1 : 0) // Why '- 1'? Because removed diffs have a dummy space at the end of the last line
-          if ( wordDiffText != " " || isAtLineEnd ){ // single space wdiffs not at the end of the line are due to text hard-wrapping, do not highlight them
-            markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
+          var isAtLineStart = range.start.column === 0
+          if ( wordDiffText != " " || isAtLineEnd ){ // Text hard-wrap hack 1: single space wdiffs not at the end of the line are due to text hard-wrapping, do not highlight them
+            // Text hard-wrap hack 2: don't highlight a word if it has only moved from the beginning of a line to the end of the previous line, or from the end of a line to the beginning of the next line
+            if ( isAtLineEnd && markersAddedAtLineStart[range.end.row+1] && markersAddedAtLineStart[range.end.row+1].text === wordDiffText.trim() ) {
+              markersAddedAtLineStart[range.end.row+1].marker.destroy()
+            } else if ( isAtLineStart && markersAddedAtLineEnd[range.end.row-1] && markersAddedAtLineEnd[range.end.row-1].text === wordDiffText.trim() ) {
+              markersAddedAtLineEnd[range.end.row-1].marker.destroy()
+            } else {
+              markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
+            }
           }
         }
       }

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -86,6 +86,9 @@ class InlineGitDiff {
     this.enabled = enabled
     this.editor.element.classList.toggle('has-inline-git-diff', this.enabled)
     this.updateStatusBar()
+    if (this.enabled) { 
+      Diff.init(this.editor.buffer) 
+    }
     this.refreshDiff()
     return true
   }

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -98,13 +98,17 @@ class InlineGitDiff {
     if (enabled === this.enabled) {
       return false
     }
-    if (enabled) {
-      var callbackOnConfirmed = (function(){
-        this.updateOnEnabled(true)
-      }).bind(this)
-      new GitHistoryView(this.editor, callbackOnConfirmed)
+    if (atom.config.get("inline-git-diff.useGitCommandToCalculateDiff")) {
+      if (enabled) {
+        var callbackOnConfirmed = (function(){
+          this.updateOnEnabled(true)
+        }).bind(this)
+        new GitHistoryView(this.editor, callbackOnConfirmed)
+      } else {
+        this.updateOnEnabled(false)
+      }
     } else {
-      this.updateOnEnabled(false)
+      this.updateOnEnabled(enabled)
     }
     return true
   }

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -5,6 +5,12 @@ const WHOLE_RANGE = Object.freeze([[0, 0], [Infinity], [Infinity]])
 const statusBar = require('./status-bar')
 const GitHistoryView = require('./git-history-view')
 
+//https://stackoverflow.com/questions/26246601/wildcard-string-comparison-in-javascript
+function matchRuleShort(str, rule) {
+  var escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1")
+  return new RegExp("^" + rule.split("*").map(escapeRegex).join(".*") + "$").test(str)
+}
+
 function buildEditorForRemovedDiff (grammar, diff, isSoftWrapped, preferredLineLength, softWrapAtPreferredLineLength) {
   const editor = new TextEditor({
     lineNumberGutterVisible: false,
@@ -111,7 +117,7 @@ class InlineGitDiff {
   }
 
   getDiffs () {
-    if (!this.diffs) this.diffs = Diff.collect(this.editor.buffer)
+    if (!this.diffs) this.diffs = Diff.collect(this.editor.buffer, this.getDiffStyle())
     return this.diffs
   }
 
@@ -154,7 +160,18 @@ class InlineGitDiff {
         editorInEditor.destroy()
       })
       markers.push(marker)
-      markers.push(...this.renderInnerLineDiff(diff, editorInEditor))
+      switch (this.getDiffStyle()) {
+        case "inner line diff":
+          if (diff.needComputeInnerLineDiff) {
+            markers.push(...this.renderInnerLineDiff(diff, editorInEditor))
+          }
+          break
+        case "word diff":
+          markers.push(...this.renderWordDiff(diff, editorInEditor))
+          break
+        case "line diff":
+        default:
+      }
     }
     return markers
   }
@@ -165,6 +182,24 @@ class InlineGitDiff {
   }
 
   renderInnerLineDiff (diff, editorInEditor) {
+    const toRange = (row, {start, length}) => Range.fromPointWithDelta([row, start], 0, length)
+    const markers = []
+
+    for (let i = 0; i < diff.innerLineDiffs.length; i++) {
+      const {added, removed} = diff.innerLineDiffs[i]
+      if (added.length) {
+        const range = toRange(diff.startRow + i, added)
+        markers.push(decorateRange(this.editor, range, {type: 'highlight', class: 'inline-git-diff-added-inner'}))
+      }
+      if (removed.length) {
+        const range = toRange(i, removed)
+        markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
+      }
+    }
+    return markers
+  }
+
+  renderWordDiff (diff, editorInEditor) {
     const toRange = (row, {startCol, length}) => Range.fromPointWithDelta([row, startCol], 0, length)
     const markers = []
 
@@ -249,6 +284,32 @@ class InlineGitDiff {
       })
     }
   }
+
+  isTextFile () {
+    const textGrammarArray = atom.config.get("inline-git-diff.textFileGrammarList").split(",").map(
+      function(item) {
+        return item.trim()
+      }
+    )
+    const currentGrammar = this.editor.getGrammar().scopeName
+    var isText = false
+    for (var i = 0; i < textGrammarArray.length; i++) {
+      if (matchRuleShort(currentGrammar, textGrammarArray[i])) {
+        isText = true
+        break
+      }
+    }
+    return isText
+  }
+
+  getDiffStyle () {
+    if (this.isTextFile()) {
+      return atom.config.get("inline-git-diff.diffStyleForTextFiles")
+    } else {
+      return atom.config.get("inline-git-diff.diffStyleForSourceFiles")
+    }
+  }
+
 }
 
 InlineGitDiff.init()

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -85,7 +85,7 @@ class InlineGitDiff {
       return false
     }
     if (enabled) {
-      new GitHistoryView(this);
+      new GitHistoryView(this)
     } else {
       this.enabled = false;
       this.editor.element.classList.toggle('has-inline-git-diff', false)

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -161,18 +161,21 @@ class InlineGitDiff {
   }
 
   renderInnerLineDiff (diff, editorInEditor) {
-    const toRange = (row, {start, length}) => Range.fromPointWithDelta([row, start], 0, length)
+    const toRange = (row, {startCol, wordLength}) => Range.fromPointWithDelta([row, startCol], 0, wordLength)
     const markers = []
 
     for (let i = 0; i < diff.innerLineDiffs.length; i++) {
-      const {added, removed} = diff.innerLineDiffs[i]
-      if (added.length) {
-        const range = toRange(diff.startRow + i, added)
+      for (let j = 0; j < diff.innerLineDiffs[i].newWords.length; j++) {
+        if (diff.innerLineDiffs[i].newWords[j].added) {
+          const range = toRange(diff.startRow + i, diff.innerLineDiffs[i].newWords[j])
         markers.push(decorateRange(this.editor, range, {type: 'highlight', class: 'inline-git-diff-added-inner'}))
       }
-      if (removed.length) {
-        const range = toRange(i, removed)
+      }
+      for (let k = 0; k < diff.innerLineDiffs[i].oldWords.length; k++) {
+        if (diff.innerLineDiffs[i].oldWords[k].removed) {
+          const range = toRange(i, diff.innerLineDiffs[i].oldWords[k])
         markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
+        }
       }
     }
     return markers

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -214,7 +214,11 @@ class InlineGitDiff {
       for (let j = 0; j < diff.wdiffLines.added[i].hunks.length; j++) {
         if (diff.wdiffLines.added[i].hunks[j].added) {
           const range = toRange(diff.startRow + i, diff.wdiffLines.added[i].hunks[j])
-          markers.push(decorateRange(this.editor, range, {type: 'highlight', class: 'inline-git-diff-added-inner'}))
+          var wordDiffText = this.editor.getTextInBufferRange(range)
+          var isAtLineEnd = range.end.column === this.editor.lineTextForBufferRow(range.end.row).length
+          if ( wordDiffText != " " || isAtLineEnd ){ // single space wdiffs not at the end of the line are due to text hard-wrapping, do not highlight them
+            markers.push(decorateRange(this.editor, range, {type: 'highlight', class: 'inline-git-diff-added-inner'}))
+          }
         }
       }
     }
@@ -222,7 +226,11 @@ class InlineGitDiff {
       for (let k = 0; k < diff.wdiffLines.removed[i].hunks.length; k++) {
         if (diff.wdiffLines.removed[i].hunks[k].removed) {
           const range = toRange(i, diff.wdiffLines.removed[i].hunks[k])
-          markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
+          var wordDiffText = editorInEditor.getTextInBufferRange(range)
+          var isAtLineEnd = range.end.column === editorInEditor.lineTextForBufferRow(range.end.row).length - (editorInEditor.getLastBufferRow() === range.end.row ? 1 : 0) // Why '- 1'? Because removed diffs have a dummy space at the end of the last line
+          if ( wordDiffText != " " || isAtLineEnd ){ // single space wdiffs not at the end of the line are due to text hard-wrapping, do not highlight them
+            markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
+          }
         }
       }
     }

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -85,20 +85,27 @@ class InlineGitDiff {
     this.updateStatusBar()
   }
 
+  updateOnEnabled (enabled) {
+    this.enabled = enabled
+    this.editor.element.classList.toggle('has-inline-git-diff', enabled)
+    this.updateStatusBar()
+    this.refreshDiff()
+  }
+
   // Return boolean to indicate action was taken or not
   toggle (enabled = !this.enabled) {
+
     if (enabled === this.enabled) {
       return false
     }
     if (enabled) {
-      new GitHistoryView(this)
+      var callbackOnConfirmed = (function(){
+        this.updateOnEnabled(true)
+      }).bind(this)
+      new GitHistoryView(this.editor, callbackOnConfirmed)
     } else {
-      this.enabled = false;
-      this.editor.element.classList.toggle('has-inline-git-diff', false)
-      this.updateStatusBar();
-      this.refreshDiff();
+      this.updateOnEnabled(false)
     }
-
     return true
   }
 

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -262,7 +262,7 @@ class InlineGitDiff {
     const diff = this.getClosestDiff()
     if (diff) {
       const originalPosition =
-        diff.kind === 'modified' && this.editor.getCursorBufferPosition()
+        diff.kind === 'modified' && this.editor.getCursorBufferPosition()  // FIXME see diff with latest t9md commit
 
       this.editor.setTextInBufferRange(diff.getRange(), diff.getRemovedText())
       if (this.markersByDiff.has(diff)) {

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -148,9 +148,9 @@ class InlineGitDiff {
         editorInEditor.destroy()
       })
       markers.push(marker)
-      if (diff.needComputeInnerLineDiff) {
+      //if (diff.needComputeInnerLineDiff) {
         markers.push(...this.renderInnerLineDiff(diff, editorInEditor))
-      }
+      //}
     }
     return markers
   }
@@ -161,20 +161,22 @@ class InlineGitDiff {
   }
 
   renderInnerLineDiff (diff, editorInEditor) {
-    const toRange = (row, {startCol, wordLength}) => Range.fromPointWithDelta([row, startCol], 0, wordLength)
+    const toRange = (row, {startCol, length}) => Range.fromPointWithDelta([row, startCol], 0, length)
     const markers = []
 
-    for (let i = 0; i < diff.innerLineDiffs.length; i++) {
-      for (let j = 0; j < diff.innerLineDiffs[i].newWords.length; j++) {
-        if (diff.innerLineDiffs[i].newWords[j].added) {
-          const range = toRange(diff.startRow + i, diff.innerLineDiffs[i].newWords[j])
-        markers.push(decorateRange(this.editor, range, {type: 'highlight', class: 'inline-git-diff-added-inner'}))
+    for (let i = 0; i < diff.wlines.added.length; i++) {
+      for (let j = 0; j < diff.wlines.added[i].hunks.length; j++) {
+        if (diff.wlines.added[i].hunks[j].added) {
+          const range = toRange(diff.startRow + i, diff.wlines.added[i].hunks[j])
+          markers.push(decorateRange(this.editor, range, {type: 'highlight', class: 'inline-git-diff-added-inner'}))
+        }
       }
-      }
-      for (let k = 0; k < diff.innerLineDiffs[i].oldWords.length; k++) {
-        if (diff.innerLineDiffs[i].oldWords[k].removed) {
-          const range = toRange(i, diff.innerLineDiffs[i].oldWords[k])
-        markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
+    }
+    for (let i = 0; i < diff.wlines.removed.length; i++) {
+      for (let k = 0; k < diff.wlines.removed[i].hunks.length; k++) {
+        if (diff.wlines.removed[i].hunks[k].removed) {
+          const range = toRange(i, diff.wlines.removed[i].hunks[k])
+          markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
         }
       }
     }

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -148,9 +148,7 @@ class InlineGitDiff {
         editorInEditor.destroy()
       })
       markers.push(marker)
-      //if (diff.needComputeInnerLineDiff) {
-        markers.push(...this.renderInnerLineDiff(diff, editorInEditor))
-      //}
+      markers.push(...this.renderInnerLineDiff(diff, editorInEditor))
     }
     return markers
   }
@@ -164,18 +162,18 @@ class InlineGitDiff {
     const toRange = (row, {startCol, length}) => Range.fromPointWithDelta([row, startCol], 0, length)
     const markers = []
 
-    for (let i = 0; i < diff.wlines.added.length; i++) {
-      for (let j = 0; j < diff.wlines.added[i].hunks.length; j++) {
-        if (diff.wlines.added[i].hunks[j].added) {
-          const range = toRange(diff.startRow + i, diff.wlines.added[i].hunks[j])
+    for (let i = 0; i < diff.wdiffLines.added.length; i++) {
+      for (let j = 0; j < diff.wdiffLines.added[i].hunks.length; j++) {
+        if (diff.wdiffLines.added[i].hunks[j].added) {
+          const range = toRange(diff.startRow + i, diff.wdiffLines.added[i].hunks[j])
           markers.push(decorateRange(this.editor, range, {type: 'highlight', class: 'inline-git-diff-added-inner'}))
         }
       }
     }
-    for (let i = 0; i < diff.wlines.removed.length; i++) {
-      for (let k = 0; k < diff.wlines.removed[i].hunks.length; k++) {
-        if (diff.wlines.removed[i].hunks[k].removed) {
-          const range = toRange(i, diff.wlines.removed[i].hunks[k])
+    for (let i = 0; i < diff.wdiffLines.removed.length; i++) {
+      for (let k = 0; k < diff.wdiffLines.removed[i].hunks.length; k++) {
+        if (diff.wdiffLines.removed[i].hunks[k].removed) {
+          const range = toRange(i, diff.wdiffLines.removed[i].hunks[k])
           markers.push(decorateRange(editorInEditor, range, {type: 'highlight', class: 'inline-git-diff-removed-inner'}))
         }
       }
@@ -223,7 +221,7 @@ class InlineGitDiff {
     const diff = this.getClosestDiff()
     if (diff) {
       const originalPosition =
-        diff.kind === 'modified' && diff.needComputeInnerLineDiff ? this.editor.getCursorBufferPosition() : undefined
+        diff.kind === 'modified' && this.editor.getCursorBufferPosition()
 
       this.editor.setTextInBufferRange(diff.getRange(), diff.getRemovedText())
       if (this.markersByDiff.has(diff)) {

--- a/lib/inline-git-diff.js
+++ b/lib/inline-git-diff.js
@@ -269,7 +269,7 @@ class InlineGitDiff {
     const diff = this.getClosestDiff()
     if (diff) {
       const originalPosition =
-        diff.kind === 'modified' && this.editor.getCursorBufferPosition()  // FIXME see diff with latest t9md commit
+        diff.kind === 'modified' && diff.needComputeInnerLineDiff ? this.editor.getCursorBufferPosition() : undefined
 
       this.editor.setTextInBufferRange(diff.getRange(), diff.getRemovedText())
       if (this.markersByDiff.has(diff)) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "engines": {
     "atom": ">=1.7.0"
   },
+  "dependencies": {
+    "diff": "^2.2.2"
+  },
   "devDependencies": {
     "prettier": "^1.10.2",
     "standard": "^10.0.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "inline-git-diff",
   "main": "./lib/main",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Inline git diffs in editor.",
   "keywords": [
     "git",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,31 @@
       "order": 3,
       "type": "boolean",
       "default": true
+    },
+    "diffStyleForTextFiles": {
+      "order": 4,
+      "type": "string",
+      "default": "word diff",
+      "enum": [
+        "line diff",
+        "inner line diff",
+        "word diff"
+      ]
+    },
+    "diffStyleForSourceFiles": {
+      "order": 5,
+      "type": "string",
+      "default": "inner line diff",
+      "enum": [
+        "line diff",
+        "inner line diff",
+        "word diff"
+      ]
+    },
+    "textFileGrammarList": {
+      "order": 6,
+      "type": "string",
+      "default": "text.*, source.asciidoc*, source.gfm"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,20 +72,26 @@
         "text"
       ]
     },
-    "maxCommitsToShowInGitHistory": {
+    "diffAlgorithm": {
       "order": 2,
+      "type": "string",
+      "default": "histogram",
+      "enum": [ "myers", "minimal", "patience", "histogram" ]
+    },
+    "maxCommitsToShowInGitHistory": {
+      "order": 3,
       "type": "integer",
       "default": 100,
       "description": "max number of commits to show in the git history prompt (where you can choose the commit against which to compare the current buffer text)"
     },
     "preselectLastCommitFromCurrentGitUser": {
-      "order": 3,
+      "order": 4,
       "type": "boolean",
       "default": false,
       "description": "preselect last commit from the current git user (instead of the last commit) in the git history prompt"
     },
     "diffStyleForTextFiles": {
-      "order": 4,
+      "order": 5,
       "type": "string",
       "default": "word diff",
       "enum": [
@@ -96,7 +102,7 @@
       "description": "Diff view style for text files (html, xml, latex, markdown, etc.). Choices are:<li><b>line diff</b>: no highlighting within diffs;</li><li><b>inner line diff</b>: if lines have not been added but just modified, highlight the text range from the first to the last modification within the diff;</li><li><b>word diff</b>: highlight the words that have been modified within each diff.</li><b>inner line diff</b> should be better for source code files, while <b>word diff</b> is more suitable for text files (documents)"
     },
     "diffStyleForSourceFiles": {
-      "order": 5,
+      "order": 6,
       "type": "string",
       "default": "inner line diff",
       "enum": [
@@ -107,7 +113,7 @@
       "description": "Diff view style for source code files (same choices as above)"
     },
     "textFileGrammarList": {
-      "order": 6,
+      "order": 7,
       "type": "string",
       "default": "text.*, source.asciidoc*, source.gfm",
       "description": "comma-separated list of grammar scope names, used by inline-git-diff to distinguish text files (documents) from source code files and apply different diff view styles accordingly (see the options above). You can use '*' as wildcard.<br>Default values should cover any plain text, asciidoc, markdown, html, latex, reStructuredText and xml files.<br>More info on Atom's grammar scope names at https://atom.io/packages/file-types"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "atom": ">=1.7.0"
   },
   "dependencies": {
+    "atom-space-pen-views": "^2.0.3",
     "diff": "^2.2.2",
-    "fs-extra": ">=8.0.0" 
+    "fs-extra": ">=8.0.0"
   },
   "devDependencies": {
     "prettier": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -75,12 +75,14 @@
     "maxCommitsToShowInGitHistory": {
       "order": 2,
       "type": "integer",
-      "default": 100
+      "default": 100,
+      "description": "max number of commits to show in the git history prompt (where you can choose the commit against which to compare the current buffer text)"
     },
     "preselectLastCommitFromCurrentGitUser": {
       "order": 3,
       "type": "boolean",
-      "default": true
+      "default": false,
+      "description": "preselect last commit from the current git user (instead of the last commit) in the git history prompt"
     },
     "diffStyleForTextFiles": {
       "order": 4,
@@ -90,7 +92,8 @@
         "line diff",
         "inner line diff",
         "word diff"
-      ]
+      ],
+      "description": "Diff view style for text files (html, xml, latex, markdown, etc.). Choices are:<li><b>line diff</b>: no highlighting within diffs;</li><li><b>inner line diff</b>: if lines have not been added but just modified, highlight the text range from the first to the last modification within the diff;</li><li><b>word diff</b>: highlight the words that have been modified within each diff.</li><b>inner line diff</b> should be better for source code files, while <b>word diff</b> is more suitable for text files (documents)"
     },
     "diffStyleForSourceFiles": {
       "order": 5,
@@ -100,12 +103,14 @@
         "line diff",
         "inner line diff",
         "word diff"
-      ]
+      ],
+      "description": "Diff view style for source code files (same choices as above)"
     },
     "textFileGrammarList": {
       "order": 6,
       "type": "string",
-      "default": "text.*, source.asciidoc*, source.gfm"
+      "default": "text.*, source.asciidoc*, source.gfm",
+      "description": "comma-separated list of grammar scope names, used by inline-git-diff to distinguish text files (documents) from source code files and apply different diff view styles accordingly (see the options above). You can use '*' as wildcard.<br>Default values should cover any plain text, asciidoc, markdown, html, latex, reStructuredText and xml files.<br>More info on Atom's grammar scope names at https://atom.io/packages/file-types"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,16 @@
         "icon",
         "text"
       ]
+    },
+    "maxCommitsToShowInGitHistory": {
+      "order": 2,
+      "type": "integer",
+      "default": 100
+    },
+    "preselectLastCommitFromCurrentGitUser": {
+      "order": 3,
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,26 +72,8 @@
         "text"
       ]
     },
-    "diffAlgorithm": {
-      "order": 2,
-      "type": "string",
-      "default": "histogram",
-      "enum": [ "myers", "minimal", "patience", "histogram" ]
-    },
-    "maxCommitsToShowInGitHistory": {
-      "order": 3,
-      "type": "integer",
-      "default": 100,
-      "description": "max number of commits to show in the git history prompt (where you can choose the commit against which to compare the current buffer text)"
-    },
-    "preselectLastCommitFromCurrentGitUser": {
-      "order": 4,
-      "type": "boolean",
-      "default": false,
-      "description": "preselect last commit from the current git user (instead of the last commit) in the git history prompt"
-    },
     "diffStyleForTextFiles": {
-      "order": 5,
+      "order": 2,
       "type": "string",
       "default": "word diff",
       "enum": [
@@ -102,7 +84,7 @@
       "description": "Diff view style for text files (html, xml, latex, markdown, etc.). Choices are:<li><b>line diff</b>: no highlighting within diffs;</li><li><b>inner line diff</b>: if lines have not been added but just modified, highlight the text range from the first to the last modification within the diff;</li><li><b>word diff</b>: highlight the words that have been modified within each diff.</li><b>inner line diff</b> should be better for source code files, while <b>word diff</b> is more suitable for text files (documents)"
     },
     "diffStyleForSourceFiles": {
-      "order": 6,
+      "order": 3,
       "type": "string",
       "default": "inner line diff",
       "enum": [
@@ -113,10 +95,40 @@
       "description": "Diff view style for source code files (same choices as above)"
     },
     "textFileGrammarList": {
-      "order": 7,
+      "order": 4,
       "type": "string",
       "default": "text.*, source.asciidoc*, source.gfm",
       "description": "comma-separated list of grammar scope names, used by inline-git-diff to distinguish text files (documents) from source code files and apply different diff view styles accordingly (see the options above). You can use '*' as wildcard.<br>Default values should cover any plain text, asciidoc, markdown, html, latex, reStructuredText and xml files.<br>More info on Atom's grammar scope names at https://atom.io/packages/file-types"
+    },
+    "useGitCommandToCalculateDiff": {
+      "order": 5,
+      "type": "boolean",
+      "default": false,
+      "description": "use git command to calculate diffs, in order to enable the options below (<b>requires git</b>)"
+    },
+    "maxCommitsToShowInGitHistory": {
+      "order": 6,
+      "type": "integer",
+      "default": 100,
+      "description": "max number of commits to show in the git history prompt (where you can choose the commit against which to compare the current buffer text)"
+    },
+    "preselectLastCommitFromCurrentGitUser": {
+      "order": 7,
+      "type": "boolean",
+      "default": false,
+      "description": "preselect last commit from the current git user (instead of the last commit) in the git history prompt"
+    },
+    "diffAlgorithm": {
+      "order": 8,
+      "type": "string",
+      "description": "algorithm to be used by git command to calculate diffs",
+      "default": "histogram",
+      "enum": [
+        "myers",
+        "minimal",
+        "patience",
+        "histogram"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "atom": ">=1.7.0"
   },
   "dependencies": {
-    "diff": "^2.2.2"
+    "diff": "^2.2.2",
+    "fs-extra": ">=8.0.0" 
   },
   "devDependencies": {
     "prettier": "^1.10.2",


### PR DESCRIPTION
I really loved and used a lot your package, but I needed something that could be used not only for code development but also for collaborative document editing through git and markdown (for more info see [here](https://github.com/alpianon/howdyadoc/tree/dev-legal)).

So I made some improvements:
- if you are editing source code you get inner-line diff, while if you are editing text files you get word diff (the package automatically detects the file type though Atom's grammar scopes); 
- you can calculate the diff from any previous commit in the git history of the edited file (I added a drop-down menu at the beginning; the last commit is pre-selected, so if you want that you can just press enter)

(More details can be found in the updated README)

I made such improvements and heavily tested and debugged them in everyday use for more than a year together with [@kappapiana](https://github.com/kappapiana/) (while doing both code editing and document editing), and now I can say they are ready for production use.

I designed all modifications in such a way that, from user's perspective, the package can be used exactly as before, if one is not interested in the new features (i.e. the package update would be seamless).

Under the hood, the main modification is the use of the git command to get file history, to get previous version of the file and to calculate the diff; and a new way to calculate word diff, different from the one you dismissed here 34adc10

I would like to see my improvements included in the official version of the package, so I'm available to explain more if you wish
